### PR TITLE
feat: dependent fields

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -177,7 +177,7 @@ class EditorControl extends React.Component {
       parentIds,
       listIndexes,
       hideField,
-      hideFieldCondition,
+      fieldCondition,
       t,
       validateMetaField,
     } = this.props;
@@ -293,7 +293,7 @@ class EditorControl extends React.Component {
               parentIds={parentIds}
               listIndexes={listIndexes}
               hideField={hideField}
-              hideFieldCondition={hideFieldCondition}
+              fieldCondition={fieldCondition}
               t={t}
               validateMetaField={validateMetaField}
             />

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -56,6 +56,9 @@ const styleStrings = {
   widgetError: `
     border-color: ${colors.errorText};
   `,
+  widgetHidden: `
+    display: none;
+  `,
 };
 
 const ControlContainer = styled.div`
@@ -168,11 +171,13 @@ class EditorControl extends React.Component {
       clearSearch,
       clearFieldErrors,
       loadEntry,
-      className,
       isSelected,
       isEditorComponent,
       isNewEditorComponent,
       parentIds,
+      listIndexes,
+      hideField,
+      hideFieldCondition,
       t,
       validateMetaField,
     } = this.props;
@@ -191,7 +196,13 @@ class EditorControl extends React.Component {
     return (
       <ClassNames>
         {({ css, cx }) => (
-          <ControlContainer className={className}>
+          <ControlContainer
+            className={cx({
+              [css`
+                ${styleStrings.widgetHidden}
+              `]: hideField,
+            })}
+          >
             {widget.globalStyles && <Global styles={coreCss`${widget.globalStyles}`} />}
             {errors && (
               <ControlErrorsList>
@@ -280,6 +291,9 @@ class EditorControl extends React.Component {
               isEditorComponent={isEditorComponent}
               isNewEditorComponent={isNewEditorComponent}
               parentIds={parentIds}
+              listIndexes={listIndexes}
+              hideField={hideField}
+              hideFieldCondition={hideFieldCondition}
               t={t}
               validateMetaField={validateMetaField}
             />

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControlPane.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControlPane.js
@@ -30,7 +30,7 @@ export default class ControlPane extends React.Component {
     });
   };
 
-  hideFieldCondition = (field, indexes = [0]) => {
+  fieldCondition = (field, indexes = [0]) => {
     const data = this.props.entry.get('data').toJS();
     const conditions = field.get('conditions');
 
@@ -90,8 +90,8 @@ export default class ControlPane extends React.Component {
               controlRef={this.controlRef}
               entry={entry}
               collection={collection}
-              hideField={field.get('conditions') && this.hideFieldCondition(field)}
-              hideFieldCondition={this.hideFieldCondition}
+              hideField={field.get('conditions') && !this.fieldCondition(field)}
+              fieldCondition={this.fieldCondition}
             />
           );
         })}

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
@@ -277,7 +277,7 @@ export default class Widget extends Component {
       isNewEditorComponent,
       parentIds,
       listIndexes,
-      hideFieldCondition,
+      fieldCondition,
       t,
     } = this.props;
     return React.createElement(controlComponent, {
@@ -324,7 +324,7 @@ export default class Widget extends Component {
       controlRef,
       parentIds,
       listIndexes,
-      hideFieldCondition,
+      fieldCondition,
       t,
     });
   }

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
@@ -123,7 +123,7 @@ export default class Widget extends Component {
       if (wrappedError.error) errors.push(wrappedError.error);
     }
 
-    this.props.onValidate(errors);
+    this.props.onValidate(this.props.hideField ? [] : errors);
   };
 
   validatePresence = (field, value) => {
@@ -276,6 +276,8 @@ export default class Widget extends Component {
       isEditorComponent,
       isNewEditorComponent,
       parentIds,
+      listIndexes,
+      hideFieldCondition,
       t,
     } = this.props;
     return React.createElement(controlComponent, {
@@ -321,6 +323,8 @@ export default class Widget extends Component {
       fieldsErrors,
       controlRef,
       parentIds,
+      listIndexes,
+      hideFieldCondition,
       t,
     });
   }

--- a/packages/netlify-cms-core/src/constants/configSchema.js
+++ b/packages/netlify-cms-core/src/constants/configSchema.js
@@ -25,6 +25,27 @@ const fieldsConfig = () => ({
       field: { $ref: 'field' },
       fields: { $ref: 'fields' },
       types: { $ref: 'fields' },
+      conditions: {
+        type: 'array',
+        minItems: 1,
+        items: {
+          type: 'object',
+          properties: {
+            fieldPath: { type: 'string' },
+            equal: { type: 'string' },
+            notEqual: { type: 'string' },
+            pattern: { type: 'string' },
+            oneOf: { type: 'array', minItems: 1, items: { type: 'string' } },
+          },
+          required: ['fieldPath'],
+          oneOf: [
+            { required: ['equal'] },
+            { required: ['notEqual'] },
+            { required: ['oneOf'] },
+            { required: ['pattern'] },
+          ],
+        },
+      },
     },
     select: { $data: '0/widget' },
     selectCases: {

--- a/packages/netlify-cms-widget-list/src/ListControl.js
+++ b/packages/netlify-cms-widget-list/src/ListControl.js
@@ -433,6 +433,8 @@ export default class ListControl extends React.Component {
       resolveWidget,
       parentIds,
       forID,
+      hideFieldCondition,
+      listIndexes: indexes,
     } = this.props;
 
     const { itemsCollapsed, keys } = this.state;
@@ -440,6 +442,7 @@ export default class ListControl extends React.Component {
     const key = keys[index];
     let field = this.props.field;
     const hasError = this.hasError(index);
+    const listIndexes = indexes?.length ? indexes.concat(index) : [index];
 
     if (this.getValueType() === valueTypes.MIXED) {
       field = getTypedFieldForValue(field, item);
@@ -489,6 +492,8 @@ export default class ListControl extends React.Component {
               data-testid={`object-control-${key}`}
               hasError={hasError}
               parentIds={[...parentIds, forID, key]}
+              listIndexes={listIndexes}
+              hideFieldCondition={hideFieldCondition}
             />
           )}
         </ClassNames>

--- a/packages/netlify-cms-widget-list/src/ListControl.js
+++ b/packages/netlify-cms-widget-list/src/ListControl.js
@@ -433,7 +433,7 @@ export default class ListControl extends React.Component {
       resolveWidget,
       parentIds,
       forID,
-      hideFieldCondition,
+      fieldCondition,
       listIndexes: indexes,
     } = this.props;
 
@@ -493,7 +493,7 @@ export default class ListControl extends React.Component {
               hasError={hasError}
               parentIds={[...parentIds, forID, key]}
               listIndexes={listIndexes}
-              hideFieldCondition={hideFieldCondition}
+              fieldCondition={fieldCondition}
             />
           )}
         </ClassNames>

--- a/packages/netlify-cms-widget-object/src/ObjectControl.js
+++ b/packages/netlify-cms-widget-object/src/ObjectControl.js
@@ -81,6 +81,8 @@ export default class ObjectControl extends React.Component {
       editorControl: EditorControl,
       controlRef,
       parentIds,
+      listIndexes,
+      hideFieldCondition,
     } = this.props;
 
     if (field.get('widget') === 'hidden') {
@@ -102,6 +104,9 @@ export default class ObjectControl extends React.Component {
         processControlRef={controlRef && controlRef.bind(this)}
         controlRef={controlRef}
         parentIds={parentIds}
+        listIndexes={listIndexes}
+        hideField={field.get('conditions') && hideFieldCondition(field, listIndexes)}
+        hideFieldCondition={hideFieldCondition}
       />
     );
   }

--- a/packages/netlify-cms-widget-object/src/ObjectControl.js
+++ b/packages/netlify-cms-widget-object/src/ObjectControl.js
@@ -82,7 +82,7 @@ export default class ObjectControl extends React.Component {
       controlRef,
       parentIds,
       listIndexes,
-      hideFieldCondition,
+      fieldCondition,
     } = this.props;
 
     if (field.get('widget') === 'hidden') {
@@ -105,8 +105,8 @@ export default class ObjectControl extends React.Component {
         controlRef={controlRef}
         parentIds={parentIds}
         listIndexes={listIndexes}
-        hideField={field.get('conditions') && hideFieldCondition(field, listIndexes)}
-        hideFieldCondition={hideFieldCondition}
+        hideField={field.get('conditions') && !fieldCondition(field, listIndexes)}
+        fieldCondition={fieldCondition}
       />
     );
   }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->
Closes #565 

Based on comment https://github.com/netlify/netlify-cms/issues/565#issuecomment-506787922, came  up with the following:
- Added support for a new field config option  `conditions`  which should hold an array of objects.
- Each object should have a `fieldPath`  attribute to reference the field, wildcards `*` are supported as well similar to relation widget attrs. And any one of `equal` ,`notEqual` , `oneOf` and `pattern` config option.

So based on the issue's OP,  a config like so would work.
```
- label: 'structure'
  name: structure
  widget: 'list'
  fields: 
    - {label: "type", name: "type", widget: "select", default: '', options: ['copy', 'divider', 'image', 'infographic', 'productCircle']}
    - label: content
      name: content
      widget: object
      fields:
        - {label: 'text', name: 'text', widget: 'markdown', conditions: [{ fieldPath: 'structure.*.type', oneOf: ['divider', 'productCircle', infographic, image, ''] }] }
        - {label: 'src', name: 'src', widget: 'image', conditions: [{ fieldPath: 'structure.*.type', oneOf: ['divider', 'productCircle', copy, ''] }] }
        - {label: 'overlay', name: 'overlay', widget: 'image', conditions: [{ fieldPath: 'structure.*.type', oneOf: ['divider', 'productCircle', copy, image, ''] }] }
```
Example config that tries to mimic dynamic dropdown:
```
- {label: "Continent", name: "continent", widget: "select", default: '', options: ['Europe', 'Asia']}
- {label: "Europe", name: "countries_europe", widget: "select", options: ['spain', 'italy', 'france'], conditions: [{ fieldPath: 'continent', oneOf: ['Asia', ''] }] }
- {label: "Asia", name: "countries_asia", widget: "select", options: ['india', 'japan', 'china'], conditions: [{ fieldPath: 'continent', oneOf: ['Europe', ''] }] }
```
To do:
- [ ] Add cypress test
- [ ] Update docs
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->


<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

