### PR TITLE
fix the display of "added in ..." versions

### DIFF
--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -9,7 +9,7 @@ We run new functionality in an open beta format from time to time. That means th
 
 ## Working with a Local Git Repository
 
-***added in netlify-cms@2.10.17 / netlify-cms-app@2.11.14***
+***added in `netlify-cms@2.10.17` / `netlify-cms-app@2.11.14`***
 
 You can connect Netlify CMS to a local Git repository, instead of working with a live repo.
 
@@ -55,7 +55,7 @@ local_backend:
 
 ## GitLab and BitBucket Editorial Workflow Support
 
-***added in netlify-cms@2.10.6 / netlify-cms-app@2.11.3***
+***added in `netlify-cms@2.10.6` / `netlify-cms-app@2.11.3`***
 
 You can enable the Editorial Workflow with the following line in your Netlify CMS `config.yml` file:
 


### PR DESCRIPTION
**Summary**

Currently on the [Beta Features](https://www.netlifycms.org/docs/beta-features/) page the "added in ..." version numbers are displaying as mailto: links, presumably because they contain an @ symbol. I assume this is undesirable? 

I clicked on one expecting to be taken to a change log associated with that version, but instead my email client opened.  Surrounding them in backticks makes them display as code instead. Alternatively we can turn them into actual links pointing to a change log, but I looked and couldn't seem to find a log (nor a matching release branch) on the website or on github. 

There is also another potential solution (adding an empty link) as explained in this [StackOverflow](https://stackoverflow.com/questions/59697538/making-it-so-email-addresses-arent-turned-into-hyperlinks) post.
  

But I haven't tested that option because I think surrounding them with backticks is a less confusing solution.

**Test plan**

n/a

**Checklist**

Please add a `x` inside each checkbox:

- [ x ] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ n/a ] Code is formatted via running `yarn format`.
- [ n/a ] Tests are passing via running `yarn test`.
- [ n/a ] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**

Didn't want to hotlink to a cute animal ... so should I have dragged and dropped an image? I'd be happy to do that on future PRs once I know the proper protocol. But hey, at least you know I read all the way to the bottom! 😄 