### PR TITLE
feat: add choose url option to file or image ts interface

### DIFF
--- a/packages/netlify-cms-core/index.d.ts
+++ b/packages/netlify-cms-core/index.d.ts
@@ -122,6 +122,7 @@ declare module 'netlify-cms-core' {
 
     media_library?: CmsMediaLibrary;
     allow_multiple?: boolean;
+    choose_url?: boolean;
     config?: any;
   }
 

--- a/packages/netlify-cms-core/src/types/redux.ts
+++ b/packages/netlify-cms-core/src/types/redux.ts
@@ -129,6 +129,7 @@ export interface CmsFieldFileOrImage {
 
   media_library?: CmsMediaLibrary;
   allow_multiple?: boolean;
+  choose_url?: boolean;
   config?: unknown;
 }
 


### PR DESCRIPTION
**Summary**

When implementing the option to add a `choose_url` flag to the image widget  https://github.com/netlify/netlify-cms/pull/5572 the TS interface declaration for `CmsFieldFileOrImage` has not been adapted accordingly which keeps the user to set this option when declaring a field with Typescript

**Test plan**

na/

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [ ] The status checks are successful (continuous integration). Those can be seen below.

![00001954-PHOTO-2016-03-24-22-03-09](https://user-images.githubusercontent.com/13048811/167374694-c354db8a-31e5-4527-a878-c7b5e8cae2ba.jpg)

