### PR TITLE
chore: consistent semicolons in js snippets

### DIFF
--- a/website/content/docs/nextjs.md
+++ b/website/content/docs/nextjs.md
@@ -84,7 +84,7 @@ module.exports = {
                 options: { mode: ['react-component'] }
             }
         )
-        return cfg;
+        return cfg
     }
 }
 ```
@@ -94,11 +94,11 @@ Almost there! The last thing we need to do is to add some content to our `pages/
 ```js
 import Head from "next/head"
 import { Component } from 'react'
-import { attributes, react as HomeContent } from '../content/home.md';
+import { attributes, react as HomeContent } from '../content/home.md'
 
 export default class Home extends Component {
   render() {
-    let { title, cats } = attributes;
+    let { title, cats } = attributes
     return (
       <>
         <Head>


### PR DESCRIPTION
**Summary**

Noticed that the js snippets in this markdown file use _mostly_ no-semicolons, but there are a couple of strays.

**Test plan**

Wishing really hard

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [👀] Tests are passing via running `yarn test`.
- [👀] The status checks are successful (continuous integration). Those can be seen below.
