### PR TITLE
chore: rm pr template checkboxes covered by CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,8 +30,5 @@ Example: The exact commands you ran and their output, screenshots / videos if th
 Please add a `x` inside each checkbox:
 
 - [ ] I have read the [contribution guidelines](../CONTRIBUTING.md).
-- [ ] Code is formatted via running `yarn format`.
-- [ ] Tests are passing via running `yarn test`.
-- [ ] The status checks are successful (continuous integration). Those can be seen below.
 
 **A picture of a cute animal (not mandatory but encouraged)**


### PR DESCRIPTION
**Summary**

My opinion: there's no need for these three checkboxes: 

- [ ] Code is formatted via running `yarn format`.
- [ ] Tests are passing via running `yarn test`.
- [ ] The status checks are successful (continuous integration). Those can be seen below.

The CI checks can run `yarn format` and `yarn test`, and the status checks speak for themselves. CI creates a ✅ , there's no need to ask a human to do it too. (plus, the status checks usually _can't_ be successful when the PR is first created, since it's the PR that triggers them in the first place, so the question doesn't really make sense.

**Test plan**

N/A

**Checklist**

Please add a `x` inside each checkbox:

- [X] I have read the [contribution guidelines](../CONTRIBUTING.md).