### PR TITLE
docs: add astro to add-to-your-site generators

### DIFF
--- a/website/content/docs/add-to-your-site.md
+++ b/website/content/docs/add-to-your-site.md
@@ -15,7 +15,7 @@ A static `admin` folder contains all Netlify CMS files, stored at the root of yo
 | ------------------------------------------------------- | --------------------- |
 | Jekyll, GitBook                                         | `/` (project root)    |
 | Hugo, Gatsby, Nuxt 2, Gridsome, Zola, Sapper, SvelteKit | `/static`             |
-| Next, Nuxt 3                                            | `/public`             |
+| Next, Nuxt 3, Astro                                     | `/public`             |
 | Hexo, Middleman, Jigsaw                                 | `/source`             |
 | Wyam                                                    | `/input`              |
 | Pelican                                                 | `/content`            |


### PR DESCRIPTION
**Summary**

Add the astro 'public' folder to the add-to-your-site documentation.

**Test plan**

N/A

**Checklist**

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [x] The status checks are successful (continuous integration). Those can be seen below.

![Cat](https://img.freepik.com/premium-photo/portrait-hipster-white-cat-wearing-sunglasses-shirt-animal-fashion-concept_43525-1120.jpg?w=360)
