### PR TITLE
feat(netlify-cms-core): add lazy property to images in Media Library

### DIFF
--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryCard.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryCard.js
@@ -92,7 +92,7 @@ class MediaLibraryCard extends React.Component {
         <CardImageWrapper>
           {isDraft ? <DraftText data-testid="draft-text">{draftText}</DraftText> : null}
           {url && isViewableImage ? (
-            <CardImage src={url} />
+            <CardImage loading="lazy" src={url} />
           ) : (
             <CardFileIcon data-testid="card-file-icon">{type}</CardFileIcon>
           )}


### PR DESCRIPTION
**Summary**

Currently when you open Media Library, all media insides are shown causing a lot of network requests even if you don't need them.
Using native image attribute `lazy` will optimize images outside the viewport and reducing unused network requests.

**Test plan**

There is not UI changes, just browser default behaviour and performance increased.

**Checklist**
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [x] The status checks are successful (continuous integration). Those can be seen below.

