### PR TITLE
Update Docs: Meta tag 'noindex' added

### DIFF
--- a/website/content/docs/add-to-your-site.md
+++ b/website/content/docs/add-to-your-site.md
@@ -46,6 +46,7 @@ In this example, we pull the `admin/index.html` file from a public CDN.
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex" />
   <title>Content Manager</title>
 </head>
 <body>


### PR DESCRIPTION
**Summary**

Adds code in docs (/docs/add-to-your-site/) that issue #6616 asked for. However, I cannot find within the codebase where I could add this line: `<meta name="robots" content="noindex" />`so by default the /admin is not picked up by Search engines. 

This is my first PR to netlify-cms, so a bit of guidance would be greatly appreciated on where to place that line of code mentioned above. 

**Test plan**

Add that line of code so the actual /admin that is deployed - so that page is not picked up by Search engines. 

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] Code is formatted via running `yarn format`.
- [x] Tests are passing via running `yarn test`.
- [x] The status checks are successful (continuous integration). Those can be seen below.

