### PR TITLE
fix: typo and GitHub casing

### DIFF
--- a/website/content/blog/github-discussions.md
+++ b/website/content/blog/github-discussions.md
@@ -1,7 +1,7 @@
 ---
-title: Github Discussions is now the official Decap forum
+title: GitHub Discussions is now the official Decap forum
 description: >-
-  What was once cateogry on Netlify Answers is now moving to Github Discussions on the main repository.
+  What was once category on Netlify Answers is now moving to GitHub Discussions on the main repository.
 date: 2023-03-09T10:30:00.000Z
 author: Martin Jagodic
 twitter_image: /img/preview-link-published.png


### PR DESCRIPTION
Fixed a typo and adjusted the casing of GitHub
