### PR TITLE
fix: aria labels

### DIFF
--- a/packages/netlify-cms-core/src/components/Collection/ViewStyleControl.js
+++ b/packages/netlify-cms-core/src/components/Collection/ViewStyleControl.js
@@ -32,12 +32,14 @@ function ViewStyleControl({ viewStyle, onChangeViewStyle }) {
   return (
     <ViewControlsSection>
       <ViewControlsButton
+        aria-label="list view option"
         isActive={viewStyle === VIEW_STYLE_LIST}
         onClick={() => onChangeViewStyle(VIEW_STYLE_LIST)}
       >
         <Icon type="list" />
       </ViewControlsButton>
       <ViewControlsButton
+        aria-label="grid view option"
         isActive={viewStyle === VIEW_STYLE_GRID}
         onClick={() => onChangeViewStyle(VIEW_STYLE_GRID)}
       >

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -227,6 +227,7 @@ class EditorControl extends React.Component {
         {({ css, cx }) => (
           <ControlContainer
             className={className}
+            aria-label={widgetName?.concat(' field')}
             css={css`
               ${isHidden && styleStrings.hidden};
             `}

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryHeader.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryHeader.js
@@ -31,7 +31,7 @@ const LibraryTitle = styled.h1`
 function MediaLibraryHeader({ onClose, title, isPrivate }) {
   return (
     <div>
-      <CloseButton onClick={onClose}>
+      <CloseButton aria-label="close" onClick={onClose}>
         <Icon type="close" />
       </CloseButton>
       <LibraryTitle isPrivate={isPrivate}>{title}</LibraryTitle>

--- a/packages/netlify-cms-core/src/components/UI/SettingsDropdown.js
+++ b/packages/netlify-cms-core/src/components/UI/SettingsDropdown.js
@@ -81,7 +81,7 @@ function SettingsDropdown({ displayUrl, isTestRepo, imageUrl, onLogoutClick, t }
         dropdownWidth="100px"
         dropdownPosition="right"
         renderButton={() => (
-          <AvatarDropdownButton>
+          <AvatarDropdownButton aria-label="account options dropdown">
             <Avatar imageUrl={imageUrl} />
           </AvatarDropdownButton>
         )}

--- a/packages/netlify-cms-ui-default/src/ObjectWidgetTopBar.js
+++ b/packages/netlify-cms-ui-default/src/ObjectWidgetTopBar.js
@@ -108,7 +108,7 @@ class ObjectWidgetTopBar extends React.Component {
     return (
       <TopBarContainer>
         <ExpandButtonContainer hasHeading={!!heading}>
-          <ExpandButton onClick={onCollapseToggle} data-testid="expand-button">
+          <ExpandButton onClick={onCollapseToggle} data-testid="expand-button" aria-label="expand">
             <Icon type="chevron" direction={collapsed ? 'right' : 'down'} size="small" />
           </ExpandButton>
           {heading}

--- a/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
+++ b/packages/netlify-cms-widget-datetime/src/DateTimeControl.js
@@ -7,7 +7,7 @@ import DateTime from 'react-datetime';
 import moment from 'moment';
 import { buttons } from 'netlify-cms-ui-default';
 
-function NowButton({ t, handleChange }) {
+function NowButton({ t, fieldName, handleChange }) {
   return (
     <div
       css={css`
@@ -19,6 +19,7 @@ function NowButton({ t, handleChange }) {
       `}
     >
       <button
+        aria-label={'set '.concat(fieldName).concat(' to now')}
         css={css`
           ${buttons.button}
           ${buttons.widget}
@@ -140,8 +141,9 @@ export default class DateTimeControl extends React.Component {
   };
 
   render() {
-    const { forID, value, classNameWrapper, setActiveStyle, t, isDisabled } = this.props;
+    const { forID, field, value, classNameWrapper, setActiveStyle, t, isDisabled } = this.props;
     const { format, dateFormat, timeFormat } = this.formats;
+    const fieldName = field.get('name');
 
     return (
       <div
@@ -160,7 +162,9 @@ export default class DateTimeControl extends React.Component {
           inputProps={{ className: classNameWrapper, id: forID }}
           utc={this.pickerUtc}
         />
-        {!isDisabled && <NowButton t={t} handleChange={v => this.handleChange(v)} />}
+        {!isDisabled && (
+          <NowButton t={t} fieldName={fieldName} handleChange={v => this.handleChange(v)} />
+        )}
       </div>
     );
   }

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/Toolbar.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/Toolbar.js
@@ -266,7 +266,11 @@ export default class Toolbar extends React.Component {
             <ToolbarToggleLabel isActive={!rawMode} offPosition>
               {t('editor.editorWidgets.markdown.richText')}
             </ToolbarToggleLabel>
-            <StyledToggle active={rawMode} onChange={onToggleMode} />
+            <StyledToggle
+              active={rawMode}
+              onChange={onToggleMode}
+              aria-label={rawMode ? 'toggle to rich text mode' : 'toggle to markdown mode'}
+            />
             <ToolbarToggleLabel isActive={rawMode}>
               {t('editor.editorWidgets.markdown.markdown')}
             </ToolbarToggleLabel>


### PR DESCRIPTION
**Summary**

Our team at ada.gov uses Netlify CMS. Recently Terri Youngblood, the accessibility consultant for the DOJ Civil Rights Section, did an audit of Netlify to verify its accessibility and identified some issues. This PR addresses those concerns - specifically aria-label updates.
![image](https://user-images.githubusercontent.com/18104884/236567049-dbd2ccd8-ace4-4221-8443-07d19ade5d63.png)
![image](https://user-images.githubusercontent.com/18104884/236567096-7764adb9-05d8-4d30-a82a-301e1ba80c59.png)
![image](https://user-images.githubusercontent.com/18104884/236567131-a17383f3-f17e-4fd6-94e5-56460ddccc54.png)
![image](https://user-images.githubusercontent.com/18104884/236567174-ce400854-fb5b-4612-949e-f5fdb4eaf684.png)

**Test plan**

Verify that the buttons indicated now have labels that can be read by a screenreader.

**Checklist**

Please add a `x` inside each checkbox:

- [x ] I have read the [contribution guidelines](../CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/18104884/236567402-7b0d58a4-f45e-437a-845c-cc3fe0bc7cb7.png)
