### PR TITLE
docs: use 'netlify-cms-app' everywhere

### DIFF
--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -408,7 +408,7 @@ Assuming you have the netlify-cms package installed to your project, manual init
 // This global flag enables manual initialization.
 window.CMS_MANUAL_INIT = true
 // Usage with import from npm package
-import CMS, { init } from 'netlify-cms'
+import CMS, { init } from 'netlify-cms-app'
 // Usage with script tag
 const { CMS, initCMS: init } = window
 /**
@@ -473,7 +473,7 @@ CMS.registerPreviewTemplate(...);
  * Assumes a webpack project with `sass-loader` and `css-loader` installed.
  * Takes advantage of the `toString` method in the return value of `css-loader`.
  */
-import CMS from 'netlify-cms';
+import CMS from 'netlify-cms-app';
 import styles from '!css-loader!sass-loader!../main.scss';
 CMS.registerPreviewStyle(styles.toString(), { raw: true });
 ```

--- a/website/content/docs/custom-widgets.md
+++ b/website/content/docs/custom-widgets.md
@@ -23,7 +23,7 @@ Register a custom widget.
 CMS.registerWidget(name, control, [preview], [schema]);
 
 // Using npm module import
-import CMS from 'netlify-cms';
+import CMS from 'netlify-cms-app';
 CMS.registerWidget(name, control, [preview], [schema]);
 ```
 
@@ -474,7 +474,7 @@ window.CMS_MANUAL_INIT = true
 
 ```javascript
 import './bootstrap.js'
-import CMS, { init } from 'netlify-cms'
+import CMS, { init } from 'netlify-cms-app'
 import 'netlify-cms/dist/cms.css'
 import { Control, Preview } from '../src'
 


### PR DESCRIPTION
Closes #2855

There were 2 references of the old package in the docs, this PR updates that.