### PR TITLE
docs: add hint to config options - fields

### DIFF
--- a/website/content/docs/configuration-options.md
+++ b/website/content/docs/configuration-options.md
@@ -349,6 +349,7 @@ The `fields` option maps editor UI widgets to field-value pairs in the saved fil
 * `widget`: defines editor UI and inputs and file field data types; details in [Widgets](../widgets)
 * `default`: specify a default value for a field; available for most widget types (see [Widgets](../widgets) for details on each widget type). Please note that field default value only works for folder collection type.
 * `required`: specify as `false` to make a field optional; defaults to `true`
+* `hint`: optionally add helper text directly below a widget. Useful for including instructions. Accepts markdown for bold, italic, strikethrough, and links.
 * `pattern`: add field validation by specifying a list with a regex pattern and an error message; more extensive validation can be achieved with [custom widgets](../custom-widgets/#advanced-field-validation)
 * `comment`: optional comment to add before the field (only supported for `yaml`)
 


### PR DESCRIPTION
Closes #5062

Adds `hint` to Fields section in Configuration options.