### PR TITLE
fix(#6355): publish button dropdown items overflow menu

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/EditorToolbar.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorToolbar.js
@@ -234,6 +234,10 @@ const RefreshPreviewButton = styled.button`
 
 const PreviewLink = RefreshPreviewButton.withComponent('a');
 
+const PublishDropDownItem = styled(DropdownItem)`
+  min-width: initial;
+`;
+
 const StatusDropdownItem = styled(DropdownItem)`
   ${Icon} {
     color: ${colors.infoText};
@@ -414,7 +418,7 @@ export class EditorToolbar extends React.Component {
           </PublishButton>
         )}
       >
-        <DropdownItem
+        <PublishDropDownItem
           label={t('editor.editorToolbar.publishNow')}
           icon="arrow"
           iconDirection="right"
@@ -422,12 +426,12 @@ export class EditorToolbar extends React.Component {
         />
         {canCreate ? (
           <>
-            <DropdownItem
+            <PublishDropDownItem
               label={t('editor.editorToolbar.publishAndCreateNew')}
               icon="add"
               onClick={onPublishAndNew}
             />
-            <DropdownItem
+            <PublishDropDownItem
               label={t('editor.editorToolbar.publishAndDuplicate')}
               icon="add"
               onClick={onPublishAndDuplicate}

--- a/packages/netlify-cms-core/src/components/Editor/EditorToolbar.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorToolbar.js
@@ -405,7 +405,7 @@ export class EditorToolbar extends React.Component {
     return canPublish ? (
       <ToolbarDropdown
         dropdownTopOverlap="40px"
-        dropdownWidth="150px"
+        dropdownWidth="200px"
         renderButton={() => (
           <PublishButton>
             {isPublishing

--- a/packages/netlify-cms-ui-default/src/styles.js
+++ b/packages/netlify-cms-ui-default/src/styles.js
@@ -347,6 +347,7 @@ const components = {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    min-width: max-content;
 
     &:last-of-type {
       border-bottom: 0;

--- a/packages/netlify-cms-ui-default/src/styles.js
+++ b/packages/netlify-cms-ui-default/src/styles.js
@@ -347,7 +347,6 @@ const components = {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    min-width: max-content;
 
     &:last-of-type {
       border-bottom: 0;


### PR DESCRIPTION
Closes #6355 

**Summary**

Fixes issue where publish drop down items were overflowing and not visible by:

1) Increasing the dropdown menu width to 200px (Looks cramped and breaks into 3 lines at current width of 150px, but happy to undo this part if people disagree)

2) Adjusting publish dropdown menu min-width property so that text wraps properly.

**Test plan**

This issue occurred in French, English, and German (Although issue only complained about French, this fixes all 3). Since these are the only locals explicitly declared in the code (That I can find) those are all I tested, however this fix should work regardless of the length (see lorem ipsum screenshot examples)

Broken - English
![Broken - English](https://github.com/decaporg/decap-cms/assets/18102814/419823bf-e6c7-4d91-b4bf-e97722d4b734)

Fixed - English
![Fixed - English](https://github.com/decaporg/decap-cms/assets/18102814/268e32fb-d1dd-44c2-89a4-8afd0d6ebd57)

Fixed - French
![Fixed - French](https://github.com/decaporg/decap-cms/assets/18102814/2ae2389f-e209-4477-973f-6b94ff9e831c)

Fixed - German
![Fixed - German](https://github.com/decaporg/decap-cms/assets/18102814/3d176e15-60a9-43ab-b8e7-bb39436c7167)

Fixed - Long Lorem Ipsum text to demo that longer text works
![Fixed - Long Lorem Ipsum Text ](https://github.com/decaporg/decap-cms/assets/18102814/19ead101-eee8-428b-9ec3-4278219e6a65)

Fixed - Longer lorem ipsum text just in case anyone wants to see it
![Fixed - Longre Lorem Ipsum Text](https://github.com/decaporg/decap-cms/assets/18102814/3e7b3395-d6fb-4980-99f5-f39dd0060491)

Image of text wrapping to 3 lines at 150px. Again, just seemed cramped like this so extended by 50px.
![Wrapping to 3 lines at 150px](https://github.com/decaporg/decap-cms/assets/18102814/d2e27ce5-aa51-475b-9f86-2cc49fbb37b7)

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
