### PR TITLE
chore: Remove extendDefaultPlugins because it is deprecated

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -28,12 +28,12 @@ const defaultPlugins = [
 ];
 
 const svgo = {
-  plugins: extendDefaultPlugins([
-    {
-      name: 'removeViewBox',
-      active: false,
+  name: 'preset-default',
+  params: {
+    overrides: {
+      removeViewBox: false,
     },
-  ]),
+  },
 };
 
 function presets() {


### PR DESCRIPTION
`extendDefaultPlugin` is deprecated and it cause warnings during the build, instead we can use `default-preset` as it is mentioned in this link [svg/svgo/pull/1513](https://github.com/svg/svgo/pull/1513)


**Motivation**
We should keep up to date


