### PR TITLE
chore(node-ci): update machine count & node version

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -66,7 +66,6 @@ jobs:
 
     strategy:
       matrix:
-        machine: [1, 2]
         node-version: [16.x, 18.x]
       fail-fast: false
 
@@ -99,13 +98,13 @@ jobs:
           IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           NODE_OPTIONS: --max-old-space-size=4096
-          MACHINE_COUNT: 4
-          MACHINE_INDEX: ${{ matrix.machine }}
+          MACHINE_COUNT: 2
+          MACHINE_INDEX: ${{ matrix.node-version }}
         if: ${{ needs.changes.outputs.cms == 'true' }}
       - uses: actions/upload-artifact@v3
         if: ${{ always() && needs.changes.outputs.cms == 'true' }}
         with:
-          name: cypress-results-${{ matrix.machine }}
+          name: cypress-results-${{ matrix.node-version }}
           path: |
             cypress/screenshots
             cypress/videos

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,13 +20,14 @@ jobs:
           filters: |
             cms:
               - '!website/**'
+
   build:
     needs: changes
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
     steps:
       - uses: actions/checkout@v3
         if: ${{ needs.changes.outputs.cms == 'true' }}
@@ -65,8 +66,8 @@ jobs:
 
     strategy:
       matrix:
-        machine: [1, 2, 3]
-        node-version: [14.x, 16.x, 18.x]
+        machine: [1, 2]
+        node-version: [16.x, 18.x]
       fail-fast: false
 
     steps:
@@ -98,7 +99,7 @@ jobs:
           IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           NODE_OPTIONS: --max-old-space-size=4096
-          MACHINE_COUNT: 3
+          MACHINE_COUNT: 4
           MACHINE_INDEX: ${{ matrix.machine }}
         if: ${{ needs.changes.outputs.cms == 'true' }}
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        node-version: [12.x, 14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
     steps:
       - uses: actions/checkout@v3
         if: ${{ needs.changes.outputs.cms == 'true' }}
@@ -65,7 +65,8 @@ jobs:
 
     strategy:
       matrix:
-        machine: [1, 2, 3, 4, 5, 6, 7, 8]
+        machine: [1, 2, 3]
+        node-version: [14.x, 16.x, 18.x]
       fail-fast: false
 
     steps:
@@ -74,7 +75,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: ${{ matrix.node-version }}
           check-latest: true
           cache: yarn
         if: ${{ needs.changes.outputs.cms == 'true' }}
@@ -97,7 +98,7 @@ jobs:
           IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           NODE_OPTIONS: --max-old-space-size=4096
-          MACHINE_COUNT: 8
+          MACHINE_COUNT: 3
           MACHINE_INDEX: ${{ matrix.machine }}
         if: ${{ needs.changes.outputs.cms == 'true' }}
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
Change runs to:
- `build` on ubuntu, macos & window, each with Node 16 and 18
- `cypress` with Node 16 and 17