### PR TITLE
fix: fill from locale error if undefined

### DIFF
--- a/packages/decap-cms-core/src/components/Editor/EditorControlPane/EditorControlPane.js
+++ b/packages/decap-cms-core/src/components/Editor/EditorControlPane/EditorControlPane.js
@@ -144,7 +144,7 @@ export default class ControlPane extends React.Component {
             locale: sourceLocale,
             isTranslatable: sourceLocale !== defaultLocale,
           });
-          this.props.onChange(field, copyValue, undefined, i18n);
+          if (copyValue) this.props.onChange(field, copyValue, undefined, i18n);
         }
       });
     };


### PR DESCRIPTION
i18n feature "Fill from another locale" produced an error if a field was undefined. This was problematic if field was an object, then an error would appear on save.