### PR TITLE
fix: change file-control default value to string

### DIFF
--- a/packages/decap-cms-widget-file/src/withFileControl.js
+++ b/packages/decap-cms-widget-file/src/withFileControl.js
@@ -202,7 +202,7 @@ function sizeOfValue(value) {
 }
 
 function valueListToArray(value) {
-  return List.isList(value) ? value.toArray() : value ?? [];
+  return List.isList(value) ? value.toArray() : value ?? '';
 }
 
 function valueListToSortableArray(value) {


### PR DESCRIPTION
Fix for issue https://github.com/decaporg/decap-cms/issues/6918

Since recent changes to image gallery & sorting, file widget value defaulted to an empty array, which caused incorrect structure when single field was used within list. This reverts to how it was before 3.0.