### PR TITLE
fix: consider i18n structure when building path regex

### DIFF
--- a/packages/decap-cms-core/src/backend.ts
+++ b/packages/decap-cms-core/src/backend.ts
@@ -47,8 +47,10 @@ import {
   getI18nBackup,
   formatI18nBackup,
   getI18nInfo,
+  I18N_STRUCTURE,
 } from './lib/i18n';
 
+import type { I18nInfo } from './lib/i18n';
 import type AssetProxy from './valueObjects/AssetProxy';
 import type {
   CmsConfig,
@@ -308,6 +310,13 @@ function collectionDepth(collection: Collection) {
   return depth;
 }
 
+function i18nRulestring(ruleString: string, { defaultLocale, structure }: I18nInfo): string {
+  if (structure === I18N_STRUCTURE.MULTIPLE_FOLDERS) {
+    return `${defaultLocale}\\/${ruleString}`;
+  }
+  return `${ruleString}\\.${defaultLocale}\\..*`;
+}
+
 function collectionRegex(collection: Collection): RegExp | undefined {
   let ruleString = '';
 
@@ -319,8 +328,7 @@ function collectionRegex(collection: Collection): RegExp | undefined {
   }
 
   if (hasI18n(collection)) {
-    const { defaultLocale } = getI18nInfo(collection) as { defaultLocale: string };
-    ruleString += `\\.${defaultLocale}\\..*`;
+    ruleString = i18nRulestring(ruleString, getI18nInfo(collection) as I18nInfo);
   }
 
   return ruleString ? new RegExp(ruleString) : undefined;

--- a/packages/decap-cms-core/src/lib/i18n.ts
+++ b/packages/decap-cms-core/src/lib/i18n.ts
@@ -24,7 +24,7 @@ export function hasI18n(collection: Collection) {
   return collection.has(I18N);
 }
 
-type I18nInfo = {
+export type I18nInfo = {
   locales: string[];
   defaultLocale: string;
   structure: I18N_STRUCTURE;


### PR DESCRIPTION
Fix issue #6913  that was caused by https://github.com/decaporg/decap-cms/pull/6898

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/decaporg/decap-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

The issue appeared when we added some filtering to prevent hitting Github gateway rate limits on large projects. When filtering by locale path in order to load only default locale for lists, we failed to consider all three possible i18n structures when building the regex.
This fix will create an appropriate path for folder structure and leave the path as is for single file structure.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**Checklist**

Please add a `x` inside each checkbox:

- [ ] I have read the [contribution guidelines](../CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
