### PR TITLE
fix: handle single file i18n when filtering

### DIFF
--- a/packages/decap-cms-core/src/backend.ts
+++ b/packages/decap-cms-core/src/backend.ts
@@ -314,7 +314,12 @@ function i18nRulestring(ruleString: string, { defaultLocale, structure }: I18nIn
   if (structure === I18N_STRUCTURE.MULTIPLE_FOLDERS) {
     return `${defaultLocale}\\/${ruleString}`;
   }
-  return `${ruleString}\\.${defaultLocale}\\..*`;
+
+  if (structure === I18N_STRUCTURE.MULTIPLE_FILES) {
+    return `${ruleString}\\.${defaultLocale}\\..*`;
+  }
+
+  return ruleString;
 }
 
 function collectionRegex(collection: Collection): RegExp | undefined {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/decaporg/decap-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

#6898 introduced filtering by path for Github, but it also introduced a couple of bugs for i18n. #6937 resolved it for multi-folder project structures and it was already working for multi-file structures. However single file structures were not being filtered right, resulting in no results appearing for collections using that structure.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
![image](https://github.com/decaporg/decap-cms/assets/1388138/09f6cd28-a566-4c64-a5b9-69901e2bc7db)
