### PR TITLE
fix(#7007) Replace validate color with tiny color 2

### DIFF
--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -158,6 +158,7 @@ collections: # A list of collections the CMS should be able to edit
           multiple: true,
         }
       - { label: 'Hidden', name: 'hidden', widget: 'hidden', default: 'hidden' }
+      - { label: 'Color', name: 'color', widget: 'color' }
       - label: 'Object'
         name: 'object'
         widget: 'object'

--- a/packages/decap-cms-widget-colorstring/package.json
+++ b/packages/decap-cms-widget-colorstring/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "react-color": "^2.18.1",
-    "validate-color": "^2.1.0"
+    "tinycolor2": "^1.4.1"
   },
   "peerDependencies": {
     "@emotion/react": "^11.11.1",

--- a/packages/decap-cms-widget-colorstring/src/ColorControl.js
+++ b/packages/decap-cms-widget-colorstring/src/ColorControl.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import ChromePicker from 'react-color';
-import validateColor from 'validate-color';
+import tinycolor from 'tinycolor2';
 import { zIndex } from 'decap-cms-ui-default';
 
 function ClearIcon() {
@@ -131,8 +131,10 @@ export default class ColorControl extends React.Component {
         )}
         <ColorSwatchBackground />
         <ColorSwatch
-          background={validateColor(this.props.value) ? this.props.value : '#fff'}
-          color={validateColor(this.props.value) ? 'rgba(255, 255, 255, 0)' : 'rgb(223, 223, 227)'}
+          background={tinycolor(this.props.value).isValid() ? this.props.value : '#fff'}
+          color={
+            tinycolor(this.props.value).isValid() ? 'rgba(255, 255, 255, 0)' : 'rgb(223, 223, 227)'
+          }
           onClick={this.handleClick}
         >
           ?

--- a/yarn.lock
+++ b/yarn.lock
@@ -17389,11 +17389,6 @@ v8-to-istanbul@^8.1.0:
     convert-source-map "^1.6.0"
     source-map "^0.7.3"
 
-validate-color@^2.1.0:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/validate-color/-/validate-color-2.2.4.tgz#77acf863458cd637ee944f604932512f6cbe6103"
-  integrity sha512-Znolz+b6CwW6eBXYld7MFM3O7funcdyRfjKC/X9hqYV/0VcC5LB/L45mff7m3dIn9wdGdNOAQ/fybNuD5P/HDw==
-
 validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"


### PR DESCRIPTION
**Summary**


Replacing validatecolor with tinycolor2. This fixes #7007 because of a snyk vulnerability for the validatecolor package.


**Test plan**

Screenshot of the application started up: 
![Screenshot 2023-12-06 at 9 48 27 AM](https://github.com/decaporg/decap-cms/assets/8705429/8c3fdc18-3931-4d1e-aa0e-35572039e22f)

Screenshot of the color picker:
![Screenshot 2023-12-06 at 10 09 21 AM](https://github.com/decaporg/decap-cms/assets/8705429/125a319a-4a04-4b1b-a7ad-3a2ad76de6b2)




**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
![images](https://github.com/decaporg/decap-cms/assets/8705429/615f5edc-5028-442e-816c-5dca56c65348)


