### PR TITLE
style: add system-ui to default font stack

### DIFF
--- a/packages/decap-cms-ui-default/src/styles.js
+++ b/packages/decap-cms-ui-default/src/styles.js
@@ -6,6 +6,7 @@ import { css, Global } from '@emotion/react';
  */
 const fonts = {
   primary: `
+    system-ui,
     -apple-system,
     BlinkMacSystemFont,
     "Segoe UI",


### PR DESCRIPTION
**Summary**

this adds "system-ui" to the default font stack.

**Motivation**

on my firefox on linux the current font stack falls back on "sans-serif" which looks awful.

**Test plan**

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).

