### PR TITLE
feat(object): variable types

### DIFF
--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -268,6 +268,20 @@ collections: # A list of collections the CMS should be able to edit
             fields:
               - { label: 'Image', name: 'image', widget: 'image' }
               - { label: 'File', name: 'file', widget: 'file' }
+      - label: Typed Object
+        name: typed_object
+        widget: object
+        types:
+          - name: copy
+            widget: object
+            fields:
+              - { name: text, widget: string }
+          - name: infographic
+            widget: object
+            fields:
+              - { name: caption, widget: string }
+              - { name: image, widget: image }
+              - { name: overlay, widget: image }
   - name: pages # a nested collection
     label: Pages
     label_singular: 'Page'

--- a/packages/decap-cms-app/src/extensions.js
+++ b/packages/decap-cms-app/src/extensions.js
@@ -18,7 +18,6 @@ import DecapCmsWidgetFile from 'decap-cms-widget-file';
 import DecapCmsWidgetSelect from 'decap-cms-widget-select';
 import DecapCmsWidgetMarkdown from 'decap-cms-widget-markdown';
 import DecapCmsWidgetList from 'decap-cms-widget-list';
-import DecapCmsWidgetObject from 'decap-cms-widget-object';
 import DecapCmsWidgetRelation from 'decap-cms-widget-relation';
 import DecapCmsWidgetBoolean from 'decap-cms-widget-boolean';
 import DecapCmsWidgetMap from 'decap-cms-widget-map';
@@ -48,7 +47,7 @@ CMS.registerWidget([
   DecapCmsWidgetSelect.Widget(),
   DecapCmsWidgetMarkdown.Widget(),
   DecapCmsWidgetList.Widget(),
-  DecapCmsWidgetList.OptionalObjectWidget(),
+  DecapCmsWidgetList.ObjectWidget(),
   DecapCmsWidgetRelation.Widget(),
   DecapCmsWidgetBoolean.Widget(),
   DecapCmsWidgetMap.Widget(),

--- a/packages/decap-cms-app/src/extensions.js
+++ b/packages/decap-cms-app/src/extensions.js
@@ -48,7 +48,7 @@ CMS.registerWidget([
   DecapCmsWidgetSelect.Widget(),
   DecapCmsWidgetMarkdown.Widget(),
   DecapCmsWidgetList.Widget(),
-  DecapCmsWidgetObject.Widget(),
+  DecapCmsWidgetList.OptionalObjectWidget(),
   DecapCmsWidgetRelation.Widget(),
   DecapCmsWidgetBoolean.Widget(),
   DecapCmsWidgetMap.Widget(),

--- a/packages/decap-cms-widget-list/src/ListControl.js
+++ b/packages/decap-cms-widget-list/src/ListControl.js
@@ -750,7 +750,7 @@ export default class ListControl extends React.Component {
   }
 }
 
-export class OptionalObjectControl extends React.Component {
+export class ObjectControlWrapper extends React.Component {
   render() {
     if (this.props.field.get('required') === false || this.props.field.get('types')) {
       return (
@@ -759,8 +759,8 @@ export class OptionalObjectControl extends React.Component {
           onChange={e => this.props.onChange(e.get(0))}
           value={List([this.props.value].filter(Boolean))}
         />
-      )
+      );
     }
-    return <ObjectControl {...this.props} />
+    return <ObjectControl {...this.props} />;
   }
 }

--- a/packages/decap-cms-widget-list/src/ListControl.js
+++ b/packages/decap-cms-widget-list/src/ListControl.js
@@ -749,3 +749,18 @@ export default class ListControl extends React.Component {
     }
   }
 }
+
+export class OptionalObjectControl extends React.Component {
+  render() {
+    if (this.props.field.get('required') === false || this.props.field.get('types')) {
+      return (
+        <ListControl
+          {...this.props}
+          onChange={e => this.props.onChange(e.get(0))}
+          value={List([this.props.value].filter(Boolean))}
+        />
+      )
+    }
+    return <ObjectControl {...this.props} />
+  }
+}

--- a/packages/decap-cms-widget-list/src/index.js
+++ b/packages/decap-cms-widget-list/src/index.js
@@ -1,6 +1,6 @@
 import DecapCmsWidgetObject from 'decap-cms-widget-object';
 
-import controlComponent, {OptionalObjectControl} from './ListControl';
+import controlComponent, { ObjectControlWrapper } from './ListControl';
 import schema from './schema';
 
 const previewComponent = DecapCmsWidgetObject.previewComponent;
@@ -15,14 +15,14 @@ function Widget(opts = {}) {
   };
 }
 
-function OptionalObjectWidget(opts = {}) {
+function ObjectWidget(opts = {}) {
   return {
     name: 'object',
-    controlComponent: OptionalObjectControl,
+    controlComponent: ObjectControlWrapper,
     previewComponent,
     ...opts,
-  }
+  };
 }
 
-export const DecapCmsWidgetList = { Widget, controlComponent, previewComponent, OptionalObjectWidget };
+export const DecapCmsWidgetList = { Widget, controlComponent, previewComponent, ObjectWidget };
 export default DecapCmsWidgetList;

--- a/packages/decap-cms-widget-list/src/index.js
+++ b/packages/decap-cms-widget-list/src/index.js
@@ -1,6 +1,6 @@
 import DecapCmsWidgetObject from 'decap-cms-widget-object';
 
-import controlComponent from './ListControl';
+import controlComponent, {OptionalObjectControl} from './ListControl';
 import schema from './schema';
 
 const previewComponent = DecapCmsWidgetObject.previewComponent;
@@ -15,5 +15,14 @@ function Widget(opts = {}) {
   };
 }
 
-export const DecapCmsWidgetList = { Widget, controlComponent, previewComponent };
+function OptionalObjectWidget(opts = {}) {
+  return {
+    name: 'object',
+    controlComponent: OptionalObjectControl,
+    previewComponent,
+    ...opts,
+  }
+}
+
+export const DecapCmsWidgetList = { Widget, controlComponent, previewComponent, OptionalObjectWidget };
 export default DecapCmsWidgetList;

--- a/website/content/docs/beta-features.md
+++ b/website/content/docs/beta-features.md
@@ -312,9 +312,9 @@ Supports all of the [`slug` templates](/docs/configuration-options#slug) and:
 * `{{media_folder}}` The global `media_folder`.
 * `{{public_folder}}` The global `public_folder`.
 
-## List Widget: Variable Types
+## List/Object Widget: Variable Types
 
-Before this feature, the [list widget](/docs/widgets/#list) allowed a set of fields to be repeated, but every list item had the same set of fields available. With variable types, multiple named sets of fields can be defined, which opens the door to highly flexible content authoring (even page building) in Decap CMS.
+Before this feature, the [list widget](/docs/widgets/#list) and [object widget](/docs/widget/#object) allowed a set of fields to be repeated, but every item had the same set of fields available. With variable types, multiple named sets of fields can be defined, which opens the door to highly flexible content authoring (even page building) in Decap CMS.
 
 **Note: this feature does not yet support default previews and requires [registering a preview template](/docs/customization#registerpreviewtemplate) in order to show up in the preview pane.**
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/decaporg/decap-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

Allow for objects to use [variable types](https://decapcms.org/docs/beta-features/#list-widget-variable-types) - effectively enabling "dependent fields" for objects. Also, improve support for objects with `required: false` - use list widget for those too, so that you can add remove the whole object from the CMS, depending on whether the content author wants it to be defined or not.

Implementation: use the `list` widget control for `objects` when either `types` is defined, or when `required=false`.

Replaces #3891 
Goes some of the way to addressing #565 (there's a limitation - dependent fields must be nested under an `object` or `list`).

**Test plan**

Added the `typed_object` field to the "kitchen sink" collection and tried it out.

Here's how it renders:

https://github.com/decaporg/decap-cms/assets/15040698/d98f7636-eba0-4f43-8f0b-9631b7dba7ee

**Help needed**

Code organisation: I don't like that the `object` widget is now actually defined in the `decap-cms-widget-list` package. The `decap-cms-widget-object` package is now reduced to a dependency of the `list` widget. To be honest I don't really see the value in splitting the widgets out into separate packages anyway, but that's another story. It was a minimal way of getting the change in. Maybe a refactor to merge the `decap-cms-widget-list` and `decap-cms-widget-object` packages could be a follow-up.

Naming: similarly, the helper which creates the widget is called `DecapCmsWidgetList.ObjectWidget()` but that's kind of confusing. It's the object widget. So maybe the following refactor would make sense:

1. Rename the `decap-cms-widget-object` package to `decap-cms-widget-struct` - it's just a general purpose control component for rendering the fields for an dictionary-like field (either object or list). It doesn't correspond to an actual widget anymore
2. Create a new package called `decap-cms-widget-object-and-list` which depends on both `decap-cms-widget-list` and `decap-cms-widget-struct`. This new package is just a thin wrapper which decides whether to use the list control or the struct control.

Testing: I tested it manually, but noticed there's are HTML files `dev-test/index.html` and `dev-test/backends/test/index.html` which contain JSON-serialized values of kitchen sink collection sample files. Am I supposed to add to those by hand?

@martinjagodic do you know who can help me answer some of these questions?

**Next steps**

Stuff I don't really want to do as part of this PR

- Part 2 of the recommendation I made in https://github.com/decaporg/decap-cms/pull/3891#issuecomment-1887545190 - right now, you can't have variable types at the top level of an entry. I started looking into this but it's fiddly.
- Some UI tweaks - it probably shouldn't say "0 typed object" before you've added the value
- The refactor described above
- A bigger refactor which gets rid of all the `decap-cms-widget-*` packages and just puts them in a subfolder inside `decap-cms-core`. I can't really see the downside of that as an end goal, but obviously it'd be a fair amount of work to actually do that, and a fair amount of work to get buy in from the maintenance team...

**Checklist**

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).