### PR TITLE
publish mode allow empty string

### DIFF
--- a/packages/decap-cms-core/index.d.ts
+++ b/packages/decap-cms-core/index.d.ts
@@ -41,7 +41,7 @@ declare module 'decap-cms-core' {
 
   export type CmsAuthScope = 'repo' | 'public_repo';
 
-  export type CmsPublishMode = 'simple' | 'editorial_workflow';
+  export type CmsPublishMode = 'simple' | 'editorial_workflow' | '';
 
   export type CmsSlugEncoding = 'unicode' | 'ascii';
 

--- a/packages/decap-cms-core/src/constants/configSchema.js
+++ b/packages/decap-cms-core/src/constants/configSchema.js
@@ -175,7 +175,7 @@ function getConfigSchema() {
       },
       publish_mode: {
         type: 'string',
-        enum: ['simple', 'editorial_workflow'],
+        enum: ['simple', 'editorial_workflow', ''],
         examples: ['editorial_workflow'],
       },
       slug: {


### PR DESCRIPTION
**Summary**

Allow empty string setting for publishing mode. Issue https://github.com//decaporg/decap-cms/issues/7102

**Test plan**

Before:
![image](https://github.com/decaporg/decap-cms/assets/10455862/a26fb282-47ac-4757-acf4-a5723a122ffe)
![image](https://github.com/decaporg/decap-cms/assets/10455862/51dfebfa-3bc0-4b74-94a1-b49d94a84887)

After:

![image](https://github.com/decaporg/decap-cms/assets/10455862/415a4f2b-1394-4581-b6f5-ca992fc41c26)


**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/master/CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
![image](https://github.com/decaporg/decap-cms/assets/10455862/370b48fc-e636-47dd-a63f-dd5a04d8e713)

