### PR TITLE
show code widget content if initially hidden

### DIFF
--- a/packages/decap-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/decap-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -147,6 +147,7 @@ class EditorControl extends React.Component {
     isFieldDuplicate: PropTypes.func,
     isFieldHidden: PropTypes.func,
     locale: PropTypes.string,
+    isParentListCollapsed: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -210,6 +211,7 @@ class EditorControl extends React.Component {
       isFieldDuplicate,
       isFieldHidden,
       locale,
+      isParentListCollapsed,
     } = this.props;
 
     const widgetName = field.get('widget');
@@ -332,6 +334,7 @@ class EditorControl extends React.Component {
               isFieldHidden={isFieldHidden}
               isLoadingAsset={isLoadingAsset}
               locale={locale}
+              isParentListCollapsed={isParentListCollapsed}
             />
             {fieldHint && (
               <ControlHint active={isSelected || this.state.styleActive} error={hasErrors}>

--- a/packages/decap-cms-core/src/components/Editor/EditorControlPane/Widget.js
+++ b/packages/decap-cms-core/src/components/Editor/EditorControlPane/Widget.js
@@ -72,6 +72,7 @@ export default class Widget extends Component {
     isFieldDuplicate: PropTypes.func,
     isFieldHidden: PropTypes.func,
     locale: PropTypes.string,
+    isParentListCollapsed: PropTypes.bool,
   };
 
   shouldComponentUpdate(nextProps) {
@@ -298,6 +299,7 @@ export default class Widget extends Component {
       isFieldDuplicate,
       isFieldHidden,
       locale,
+      isParentListCollapsed,
     } = this.props;
 
     return React.createElement(controlComponent, {
@@ -350,6 +352,7 @@ export default class Widget extends Component {
       isFieldDuplicate,
       isFieldHidden,
       locale,
+      isParentListCollapsed,
     });
   }
 }

--- a/packages/decap-cms-widget-code/src/CodeControl.js
+++ b/packages/decap-cms-widget-code/src/CodeControl.js
@@ -68,6 +68,7 @@ export default class CodeControl extends React.Component {
     forID: PropTypes.string.isRequired,
     classNameWrapper: PropTypes.string.isRequired,
     widget: PropTypes.object.isRequired,
+    isParentListCollapsed: PropTypes.bool,
   };
 
   keys = this.getKeys(this.props.field);
@@ -83,9 +84,16 @@ export default class CodeControl extends React.Component {
     lastKnownValue: this.valueIsMap() ? this.props.value?.get(this.keys.code) : this.props.value,
   };
 
+  visibility = {
+    isInvisibleOnInit: this.props.isParentListCollapsed === true,
+    isRefreshedAfterInvisible: false,
+  };
+
   shouldComponentUpdate(nextProps, nextState) {
     return (
-      !isEqual(this.state, nextState) || this.props.classNameWrapper !== nextProps.classNameWrapper
+      !isEqual(this.state, nextState) ||
+      this.props.classNameWrapper !== nextProps.classNameWrapper ||
+      (this.visibility.isInvisibleOnInit && !this.visibility.isRefreshedAfterInvisible)
     );
   }
 
@@ -97,6 +105,14 @@ export default class CodeControl extends React.Component {
 
   componentDidUpdate(prevProps, prevState) {
     this.updateCodeMirrorProps(prevState);
+    // when initially hidden and then shown, codeMirror content is not visible
+    if (
+      this.visibility.isInvisibleOnInit &&
+      !this.visibility.isRefreshedAfterInvisible &&
+      !this.props.listCollapsed
+    ) {
+      this.refreshCodeMirrorInstance();
+    }
   }
 
   updateCodeMirrorProps(prevState) {
@@ -104,6 +120,13 @@ export default class CodeControl extends React.Component {
     const changedProps = getChangedProps(prevState, this.state, keys);
     if (changedProps) {
       this.handleChangeCodeMirrorProps(changedProps);
+    }
+  }
+
+  refreshCodeMirrorInstance() {
+    if (this.cm?.getWrapperElement().offsetHeight) {
+      this.cm.refresh();
+      this.visibility.isRefreshedAfterInvisible = true;
     }
   }
 

--- a/packages/decap-cms-widget-object/src/ObjectControl.js
+++ b/packages/decap-cms-widget-object/src/ObjectControl.js
@@ -40,6 +40,7 @@ export default class ObjectControl extends React.Component {
     hasError: PropTypes.bool,
     t: PropTypes.func,
     locale: PropTypes.string,
+    collapsed: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -87,6 +88,7 @@ export default class ObjectControl extends React.Component {
       isFieldDuplicate,
       isFieldHidden,
       locale,
+      collapsed,
     } = this.props;
 
     if (field.get('widget') === 'hidden') {
@@ -116,6 +118,7 @@ export default class ObjectControl extends React.Component {
         isFieldDuplicate={isFieldDuplicate}
         isFieldHidden={isFieldHidden}
         locale={locale}
+        isParentListCollapsed={collapsed}
       />
     );
   }


### PR DESCRIPTION
**Summary**

fixes #6812 
code widgets now shows content if it's inside list.

**Test plan**

config.yml
```
local_backend: true

backend:
  name: proxy
  proxy_url: http://localhost:8082/api/v1
  branch: main

# These lines should *not* be indented
media_folder: "static/img" # Media files will be stored in the repo under static/images/uploads
public_folder: "/img/" # The src attribute for uploaded media will begin with /images/uploads

collections:
  - name: docs
    label: Docs
    label_singular: "Doc"
    folder: "docs"
    path: "{{title}}/{{id}}"
    slug: "{{id}}"
    create: true
    nested: { depth: 100 } # accepts an optional summary template
    allow_nesting: true
    meta: { path: { widget: string, label: "Path", index_file: "index" } }
    fields:
      - { label: "title", name: "title", widget: "string" }
      - {
          name: "code test",
          label: "Example Code",
          widget: "code",
          default_language: "jsx",
          output_code_only: true,
          hint: "Add or choose a file with valid React or MUI code. This will render the preview area of the example. Specify imports as needed in your file.",
        }
      - {
        name: "items",
        label: "Examples",
        widget: "list",
        fields: [
          {
            name: "name",
            label: "Name",
            widget: "string",
            hint: "This is used to label the example in the admin area. It does not show on the website.",
          },
          {
            name: "type",
            label: "Type",
            widget: "select",
            options: [
              {
                label: "Theme Preview",
                value: "",
              },
              {
                label: "Do (Success)",
                value: "success",
              },
              {
                label: "Don't (Error)",
                value: "error",
              },
            ],
          },
          {
            name: "code",
            label: "Example Code",
            widget: "code",
            default_language: "jsx",
            output_code_only: true,
            hint: "Add or choose a file with valid React or MUI code. This will render the preview area of the example. Specify imports as needed in your file.",
          },
          {
            name: "description",
            label: "Description",
            widget: "text",
            hint: "Use this area to provide notes and context about this example. Line breaks and code are not supported and will be removed on save.\n &#x26A0;",
          },
          {
            name: "items inside",
            label: "Examples inside",
            widget: "list",
            fields: [
              {
                name: "name",
                label: "Name",
                widget: "string",
                hint: "This is used to label the example in the admin area. It does not show on the website.",
              },
              {
                name: "type",
                label: "Type",
                widget: "select",
                options: [
                  {
                    label: "Theme Preview",
                    value: "",
                  },
                  {
                    label: "Do (Success)",
                    value: "success",
                  },
                  {
                    label: "Don't (Error)",
                    value: "error",
                  },
                ],
              },
              {
                name: "code",
                label: "Example Code",
                widget: "code",
                default_language: "jsx",
                output_code_only: true,
                hint: "Add or choose a file with valid React or MUI code. This will render the preview area of the example. Specify imports as needed in your file.",
              },
              {
                name: "description",
                label: "Description",
                widget: "text",
                hint: "Use this area to provide notes and context about this example. Line breaks and code are not supported and will be removed on save.\n &#x26A0;",
              },
            ]
          }
        ]
      }

```
Before:
![image](https://github.com/decaporg/decap-cms/assets/10455862/19de5084-7606-4032-b8be-282cc5ec228c)

After:
![image](https://github.com/decaporg/decap-cms/assets/10455862/2f8f7747-49a2-4cb5-aca8-c93f6ad55954)


**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/master/CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
![image](https://github.com/decaporg/decap-cms/assets/10455862/71796571-08a4-4f8b-9536-9c069fea264c)
