### PR TITLE
typo fix

### DIFF
--- a/packages/decap-cms-widget-code/src/CodeControl.js
+++ b/packages/decap-cms-widget-code/src/CodeControl.js
@@ -109,7 +109,7 @@ export default class CodeControl extends React.Component {
     if (
       this.visibility.isInvisibleOnInit &&
       !this.visibility.isRefreshedAfterInvisible &&
-      !this.props.listCollapsed
+      !this.props.isParentListCollapsed
     ) {
       this.refreshCodeMirrorInstance();
     }


### PR DESCRIPTION
**Summary**

/pull/7131 typo fix. When renaming variables I missed one. Code works in both cases, because it's checking if undefined variable is not truthy and because there are additional conditions when refreshing codemirror instance. But it's unnecessarily trying to refresh instance even if parent list is still collapsed

**Test plan**

see PR for more info

**Checklist**

Please add a `x` inside each checkbox:

- [x ] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/master/CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
