### PR TITLE
Specify Lock file version in `.npmrc` config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 legacy-peer-deps=true
+lockfileVersion=3


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/decaporg/decap-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

By setting lockfileVersion to 3 it instructs npm to use the third version of the lockfile format.

This helps prevent the lockfileversion from changing (reverting to an older version).

Info: https://docs.npmjs.com/cli/v7/configuring-npm/package-lock-json#lockfileversion

**Test plan**

n/a

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/master/CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**

![baby-seal](https://github.com/decaporg/decap-cms/assets/1212885/d8c62f18-0065-41cb-90fb-c292bf12d0d7)

