### PR TITLE
feat: filtering for relation widget (#2405)

### DIFF
--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -66,7 +66,7 @@ collections: # A list of collections the CMS should be able to edit
       - { label: 'Title', name: 'title', widget: 'string', tagname: 'h1' }
       - { label: 'Body', name: 'body', widget: 'markdown', hint: 'Main content goes here.' }
       - { name: 'gallery', widget: 'image', choose_url: true, media_library: {config: {multiple: true, max_files: 999}}}
-      - { name: 'post', widget: relation, collection: posts, multiple: true, search_fields: [ "title" ], display_fields: [ "title" ], value_field: "{{slug}}"}
+      - { name: 'post', widget: relation, collection: posts, multiple: true, search_fields: [ "title" ], display_fields: [ "title" ], value_field: "{{slug}}", filters: [ {field: "draft", values: [false]} ] }
       - name: authors
         label: Authors
         label_singular: 'Author'

--- a/packages/decap-cms-widget-relation/src/RelationControl.js
+++ b/packages/decap-cms-widget-relation/src/RelationControl.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { components } from 'react-select';
 import AsyncSelect from 'react-select/async';
-import { debounce, filter, find, get, isEmpty, last, uniqBy } from 'lodash';
+import { debounce, find, get, isEmpty, last, uniqBy } from 'lodash';
 import { fromJS, List, Map } from 'immutable';
 import { reactSelectStyles } from 'decap-cms-ui-default';
 import { stringTemplate, validations } from 'decap-cms-lib-widgets';
@@ -379,10 +379,10 @@ export default class RelationControl extends React.Component {
     const searchFieldsArray = getFieldArray(field.get('search_fields'));
     const file = field.get('file');
 
-    query(forID, collection, searchFieldsArray, term, file, optionsLength).then(({ payload }) => {
+    query(forID, collection, searchFieldsArray, term, file).then(({ payload }) => {
       const hits = payload.hits || [];
       const options = this.parseHitOptions(hits);
-      const uniq = uniqOptions(this.state.initialOptions, options);
+      const uniq = uniqOptions(this.state.initialOptions, options).slice(0, optionsLength);
       callback(uniq);
     });
   }, 500);

--- a/packages/decap-cms-widget-relation/src/__tests__/relation.spec.js
+++ b/packages/decap-cms-widget-relation/src/__tests__/relation.spec.js
@@ -109,7 +109,6 @@ const emptyFilterFieldConfig = {
   ],
 };
 
-
 function generateHits(length) {
   const hits = Array.from({ length }, (val, idx) => {
     const title = `Post # ${idx + 1}`;
@@ -247,11 +246,7 @@ class RelationController extends React.Component {
       hits = [queryHits[queryHits.length - 4]];
     }
 
-    console.log(hits.length)
-
     hits = hits.slice(0, optionsLength);
-    
-    console.log(hits.length, optionsLength)
 
     this.setQueryHits(hits);
 
@@ -409,7 +404,9 @@ describe('Relation widget', () => {
     const value = 'post-number-1';
     const label = 'post-number-1 post-number-1 md';
     const metadata = {
-      post: { posts: { 'post-number-1': { title: 'Post # 1', draft: true, slug: 'post-number-1' } } },
+      post: {
+        posts: { 'post-number-1': { title: 'Post # 1', draft: true, slug: 'post-number-1' } },
+      },
     };
 
     fireEvent.keyDown(input, { key: 'ArrowDown' });
@@ -553,7 +550,7 @@ describe('Relation widget', () => {
       const field = fromJS(filterBooleanFieldConfig);
       const { getAllByText, input } = setup({ field });
       const expectedOptions = [];
-      for (let i = 2; i <= 20; i += 2) {
+      for (let i = 2; i <= 25; i += 2) {
         expectedOptions.push(`Post # ${i} post-number-${i}`);
       }
       fireEvent.keyDown(input, { key: 'ArrowDown' });
@@ -561,11 +558,13 @@ describe('Relation widget', () => {
       await waitFor(() => {
         const displayedOptions = getAllByText(/^Post # (\d{1,2}) post-number-\1$/);
         expect(displayedOptions).toHaveLength(expectedOptions.length);
-        for (let i = 0; i < expectedOptions.length; i++) {  
+        for (let i = 0; i < expectedOptions.length; i++) {
           const expectedOption = expectedOptions[i];
-          const optionFound = displayedOptions.some(option => option.textContent === expectedOption);
+          const optionFound = displayedOptions.some(
+            option => option.textContent === expectedOption,
+          );
           expect(optionFound).toBe(true);
-        }  
+        }
       });
     });
 
@@ -573,22 +572,24 @@ describe('Relation widget', () => {
       const field = fromJS(filterStringFieldConfig);
       const { getAllByText, input } = setup({ field });
       const expectedOptions = [
-        'Post # 1 post-number-1',  
-        'Post # 2 post-number-2',  
-        'Post # 7 post-number-7',  
-        'Post # 9 post-number-9',  
-        'Post # 15 post-number-15' 
+        'Post # 1 post-number-1',
+        'Post # 2 post-number-2',
+        'Post # 7 post-number-7',
+        'Post # 9 post-number-9',
+        'Post # 15 post-number-15',
       ];
       fireEvent.keyDown(input, { key: 'ArrowDown' });
 
       await waitFor(() => {
         const displayedOptions = getAllByText(/^Post # (\d{1,2}) post-number-\1$/);
         expect(displayedOptions).toHaveLength(expectedOptions.length);
-        for (let i = 0; i < expectedOptions.length; i++) {  
+        for (let i = 0; i < expectedOptions.length; i++) {
           const expectedOption = expectedOptions[i];
-          const optionFound = displayedOptions.some(option => option.textContent === expectedOption);
+          const optionFound = displayedOptions.some(
+            option => option.textContent === expectedOption,
+          );
           expect(optionFound).toBe(true);
-        }  
+        }
       });
     });
 
@@ -596,21 +597,23 @@ describe('Relation widget', () => {
       const field = fromJS(multipleFiltersFieldConfig);
       const { getAllByText, input } = setup({ field });
       const expectedOptions = [
-        'Post # 1 post-number-1',  
-        'Post # 7 post-number-7',  
-        'Post # 9 post-number-9',  
-        'Post # 15 post-number-15' 
+        'Post # 1 post-number-1',
+        'Post # 7 post-number-7',
+        'Post # 9 post-number-9',
+        'Post # 15 post-number-15',
       ];
       fireEvent.keyDown(input, { key: 'ArrowDown' });
 
       await waitFor(() => {
         const displayedOptions = getAllByText(/^Post # (\d{1,2}) post-number-\1$/);
         expect(displayedOptions).toHaveLength(expectedOptions.length);
-        for (let i = 0; i < expectedOptions.length; i++) {  
+        for (let i = 0; i < expectedOptions.length; i++) {
           const expectedOption = expectedOptions[i];
-          const optionFound = displayedOptions.some(option => option.textContent === expectedOption);
+          const optionFound = displayedOptions.some(
+            option => option.textContent === expectedOption,
+          );
           expect(optionFound).toBe(true);
-        }  
+        }
       });
     });
 
@@ -623,6 +626,5 @@ describe('Relation widget', () => {
         expect(() => getAllByText(/^Post # (\d{1,2}) post-number-\1$/)).toThrow(Error);
       });
     });
-
   });
 });

--- a/packages/decap-cms-widget-relation/src/__tests__/relation.spec.js
+++ b/packages/decap-cms-widget-relation/src/__tests__/relation.spec.js
@@ -49,12 +49,74 @@ const nestedFieldConfig = {
   value_field: 'title',
 };
 
+const filterBooleanFieldConfig = {
+  name: 'post',
+  collection: 'posts',
+  display_fields: ['title', 'slug'],
+  search_fields: ['title', 'body'],
+  value_field: 'title',
+  filters: [
+    {
+      field: 'draft',
+      values: [false],
+    },
+  ],
+};
+
+const filterStringFieldConfig = {
+  name: 'post',
+  collection: 'posts',
+  display_fields: ['title', 'slug'],
+  search_fields: ['title', 'body'],
+  value_field: 'title',
+  filters: [
+    {
+      field: 'title',
+      values: ['Post # 1', 'Post # 2', 'Post # 7', 'Post # 9', 'Post # 15'],
+    },
+  ],
+};
+
+const multipleFiltersFieldConfig = {
+  name: 'post',
+  collection: 'posts',
+  display_fields: ['title', 'slug'],
+  search_fields: ['title', 'body'],
+  value_field: 'title',
+  filters: [
+    {
+      field: 'title',
+      values: ['Post # 1', 'Post # 2', 'Post # 7', 'Post # 9', 'Post # 15'],
+    },
+    {
+      field: 'draft',
+      values: [true],
+    },
+  ],
+};
+
+const emptyFilterFieldConfig = {
+  name: 'post',
+  collection: 'posts',
+  display_fields: ['title', 'slug'],
+  search_fields: ['title', 'body'],
+  value_field: 'title',
+  filters: [
+    {
+      field: 'draft',
+      values: [],
+    },
+  ],
+};
+
+
 function generateHits(length) {
   const hits = Array.from({ length }, (val, idx) => {
     const title = `Post # ${idx + 1}`;
     const slug = `post-number-${idx + 1}`;
+    const draft = idx % 2 === 0;
     const path = `posts/${slug}.md`;
-    return { collection: 'posts', data: { title, slug }, slug, path };
+    return { collection: 'posts', data: { title, slug, draft }, slug, path };
   });
 
   return [
@@ -185,7 +247,11 @@ class RelationController extends React.Component {
       hits = [queryHits[queryHits.length - 4]];
     }
 
+    console.log(hits.length)
+
     hits = hits.slice(0, optionsLength);
+    
+    console.log(hits.length, optionsLength)
 
     this.setQueryHits(hits);
 
@@ -277,7 +343,7 @@ describe('Relation widget', () => {
     const value = 'Post # 1';
     const label = 'Post # 1 post-number-1';
     const metadata = {
-      post: { posts: { 'Post # 1': { title: 'Post # 1', slug: 'post-number-1' } } },
+      post: { posts: { 'Post # 1': { title: 'Post # 1', draft: true, slug: 'post-number-1' } } },
     };
 
     fireEvent.keyDown(input, { key: 'ArrowDown' });
@@ -295,7 +361,7 @@ describe('Relation widget', () => {
     const { getByText, onChangeSpy, setQueryHitsSpy } = setup({ field, value });
     const label = 'Post # 1 post-number-1';
     const metadata = {
-      post: { posts: { 'Post # 1': { title: 'Post # 1', slug: 'post-number-1' } } },
+      post: { posts: { 'Post # 1': { title: 'Post # 1', draft: true, slug: 'post-number-1' } } },
     };
 
     setQueryHitsSpy(generateHits(1));
@@ -343,7 +409,7 @@ describe('Relation widget', () => {
     const value = 'post-number-1';
     const label = 'post-number-1 post-number-1 md';
     const metadata = {
-      post: { posts: { 'post-number-1': { title: 'Post # 1', slug: 'post-number-1' } } },
+      post: { posts: { 'post-number-1': { title: 'Post # 1', draft: true, slug: 'post-number-1' } } },
     };
 
     fireEvent.keyDown(input, { key: 'ArrowDown' });
@@ -399,10 +465,10 @@ describe('Relation widget', () => {
       const field = fromJS({ ...fieldConfig, multiple: true });
       const { getByText, input, onChangeSpy } = setup({ field });
       const metadata1 = {
-        post: { posts: { 'Post # 1': { title: 'Post # 1', slug: 'post-number-1' } } },
+        post: { posts: { 'Post # 1': { title: 'Post # 1', draft: true, slug: 'post-number-1' } } },
       };
       const metadata2 = {
-        post: { posts: { 'Post # 2': { title: 'Post # 2', slug: 'post-number-2' } } },
+        post: { posts: { 'Post # 2': { title: 'Post # 2', draft: false, slug: 'post-number-2' } } },
       };
 
       fireEvent.keyDown(input, { key: 'ArrowDown' });
@@ -480,5 +546,83 @@ describe('Relation widget', () => {
         expect(getByText('category 2')).toBeInTheDocument();
       });
     });
+  });
+
+  describe('with filter', () => {
+    it('should list the 10 option hits on initial load using a filter on boolean value', async () => {
+      const field = fromJS(filterBooleanFieldConfig);
+      const { getAllByText, input } = setup({ field });
+      const expectedOptions = [];
+      for (let i = 2; i <= 20; i += 2) {
+        expectedOptions.push(`Post # ${i} post-number-${i}`);
+      }
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+      await waitFor(() => {
+        const displayedOptions = getAllByText(/^Post # (\d{1,2}) post-number-\1$/);
+        expect(displayedOptions).toHaveLength(expectedOptions.length);
+        for (let i = 0; i < expectedOptions.length; i++) {  
+          const expectedOption = expectedOptions[i];
+          const optionFound = displayedOptions.some(option => option.textContent === expectedOption);
+          expect(optionFound).toBe(true);
+        }  
+      });
+    });
+
+    it('should list the 5 option hits on initial load using a filter on string value', async () => {
+      const field = fromJS(filterStringFieldConfig);
+      const { getAllByText, input } = setup({ field });
+      const expectedOptions = [
+        'Post # 1 post-number-1',  
+        'Post # 2 post-number-2',  
+        'Post # 7 post-number-7',  
+        'Post # 9 post-number-9',  
+        'Post # 15 post-number-15' 
+      ];
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+      await waitFor(() => {
+        const displayedOptions = getAllByText(/^Post # (\d{1,2}) post-number-\1$/);
+        expect(displayedOptions).toHaveLength(expectedOptions.length);
+        for (let i = 0; i < expectedOptions.length; i++) {  
+          const expectedOption = expectedOptions[i];
+          const optionFound = displayedOptions.some(option => option.textContent === expectedOption);
+          expect(optionFound).toBe(true);
+        }  
+      });
+    });
+
+    it('should list 4 option hits on initial load using multiple filters', async () => {
+      const field = fromJS(multipleFiltersFieldConfig);
+      const { getAllByText, input } = setup({ field });
+      const expectedOptions = [
+        'Post # 1 post-number-1',  
+        'Post # 7 post-number-7',  
+        'Post # 9 post-number-9',  
+        'Post # 15 post-number-15' 
+      ];
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+      await waitFor(() => {
+        const displayedOptions = getAllByText(/^Post # (\d{1,2}) post-number-\1$/);
+        expect(displayedOptions).toHaveLength(expectedOptions.length);
+        for (let i = 0; i < expectedOptions.length; i++) {  
+          const expectedOption = expectedOptions[i];
+          const optionFound = displayedOptions.some(option => option.textContent === expectedOption);
+          expect(optionFound).toBe(true);
+        }  
+      });
+    });
+
+    it('should list 0 option hits on initial load on empty filter values array', async () => {
+      const field = fromJS(emptyFilterFieldConfig);
+      const { getAllByText, input } = setup({ field });
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+      await waitFor(() => {
+        expect(() => getAllByText(/^Post # (\d{1,2}) post-number-\1$/)).toThrow(Error);
+      });
+    });
+
   });
 });

--- a/packages/decap-cms-widget-relation/src/schema.js
+++ b/packages/decap-cms-widget-relation/src/schema.js
@@ -9,6 +9,17 @@ export default {
     max: { type: 'integer' },
     display_fields: { type: 'array', minItems: 1, items: { type: 'string' } },
     options_length: { type: 'integer' },
+    filters: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          field: { type: 'string' },
+          values: { type: 'array', minItems: 1, items: { type: ['string', 'boolean'] } },
+        },
+        required: ['field', 'values'],
+      },
+    },
   },
   oneOf: [
     {


### PR DESCRIPTION
**Summary**

This PR adds a `filters` field for the Relation widget which allows adding filters by which the available options are filtered on. This was requested in issue #2405 (and also by myself :)). 

How it works is that you can add "filters" which are a pair of `field` and the allowed `values`, where the widget will only show options (collection items) that satisfy all the "filters". An collection item satisfies a filter if the value of `field` is one of the values in `values`.

**Example**
```
collections:
  - name: posts
    label: Posts
    folder: _posts
    create: true
    fields:
      - label: Title
        name: title
        widget: string
      - label: Draft
        name: draft
        widget: boolean
        default: true
      - label: Body
        name: body
        widget: markdown
  - name: restaurants
    label: Restaurants
    folder: _restaurants
    create: true
    fields:
      - label: Title
        name: title
        widget: string
      - label: Body
        name: body
        widget: markdown
      - label: Posts
        name: posts
        widget: relation
        collection: posts
        multiple: true
        search_fields: [title]
        display_fields: [title]
        value_field: '{{slug}}'
        filters: 
          - field: draft
            values: [false]
```
In this example the relation widget in the restaurants collection will only show and allow options that are posts which are not a draft (i.e. `draft`field is `false`). Say, we have 20 posts in the CMS of which 5 have `draft` set to true, then we will only see the other 15 posts as option in the relation widget.

Multiple filters can be added:
```
filters: 
  - field: draft
    values: [false]
  - field: title
     values: ['post about cats', 'post about dogs']
```
In this case only the posts with `draft` set to `false` and a title that is either 'posts about cats' or 'post about dogs' will be options seen in the relation widget.

**Test plan**

Added the following unit tests:
```
with filter
      ✓ should list the 10 out of 20 option hits on initial load using a filter on boolean value (532 ms)
      ✓ should list the 5 out of 20 option hits on initial load using a filter on string value (528 ms)
      ✓ should list 4 out of 20 option hits on initial load using multiple filters (523 ms)
      ✓ should list 0 out of 20 option hits on initial load on conflicting filter values (25 ms)
```

After adding the following filter to the dev-test `config.yml`:
`filters: [ {field: "draft", values: [false]} ]`
These are the results of the filter:

- Out of the 23 posts items that are in the posts collection by default in the dev-test cms, the filter on `draft` with value `false` gives the following possible options: (note that without the filter you would see posts 1 to 20 by default)
<img width="812" alt="Screenshot 2024-03-26 at 15 44 00" src="https://github.com/decaporg/decap-cms/assets/72915212/d66f47bc-9261-4544-ab79-5c2342d908b3">

- Choosing, deleting, clearing options works the same:
<img width="564" alt="Screenshot 2024-03-26 at 16 30 53" src="https://github.com/decaporg/decap-cms/assets/72915212/9c185a04-a9dd-48ce-9023-178820c23709">

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
![IMG_0285](https://github.com/decaporg/decap-cms/assets/72915212/86e661af-f470-4744-908e-76538851814c)
my 15 week old pup :)