### PR TITLE
fix: handle single values in multi select relation widget

### DIFF
--- a/packages/decap-cms-widget-relation/src/RelationControl.js
+++ b/packages/decap-cms-widget-relation/src/RelationControl.js
@@ -259,11 +259,16 @@ export default class RelationControl extends React.Component {
 
       //set metadata
       this.mounted &&
-        onChange(filteredValue.length === 1 ? filteredValue[0] : fromJS(filteredValue), {
-          [field.get('name')]: {
-            [field.get('collection')]: metadata,
+        onChange(
+          filteredValue.length === 1 && !this.isMultiple()
+            ? filteredValue[0]
+            : fromJS(filteredValue),
+          {
+            [field.get('name')]: {
+              [field.get('collection')]: metadata,
+            },
           },
-        });
+        );
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
This should patch up a bug that was introduced here: https://github.com/decaporg/decap-cms/pull/7161
There is an edge case that we use for our client where relation widget is collapsed within an list and if the widget wasn't displayed right away it would populate the value as if it was a single value field and after saving the format would be corrupted. 

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**
Add the following field to the list of authors in config.yml
```
- { name: 'posts', widget: relation, collection: posts, multiple: true, search_fields: [ "title" ], display_fields: [ "title" ], value_field: "{{slug}}", filters: [ {field: "draft", values: [false]} ] }
```
In settings > authors add a single related post, publish (so far so good), close and open authors again. The value would be blank before this patch but is correctly populated now.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
