### PR TITLE
fix(datetime-widget): revert default date format to include timezone

### DIFF
--- a/dev-test/backends/azure/config.yml
+++ b/dev-test/backends/azure/config.yml
@@ -30,6 +30,7 @@ collections:
       - label: Publish Date
         name: date
         widget: datetime
+        format: 'YYYY-MM-DDTHH:mm'
       - label: Description
         name: description
         widget: text

--- a/dev-test/backends/bitbucket/config.yml
+++ b/dev-test/backends/bitbucket/config.yml
@@ -28,6 +28,7 @@ collections:
       - label: Publish Date
         name: date
         widget: datetime
+        format: 'YYYY-MM-DDTHH:mm'
       - label: Description
         name: description
         widget: text

--- a/dev-test/backends/git-gateway/config.yml
+++ b/dev-test/backends/git-gateway/config.yml
@@ -27,6 +27,7 @@ collections:
       - label: Publish Date
         name: date
         widget: datetime
+        format: 'YYYY-MM-DDTHH:mm'
       - label: Description
         name: description
         widget: text

--- a/dev-test/backends/gitea/config.yml
+++ b/dev-test/backends/gitea/config.yml
@@ -28,6 +28,7 @@ collections:
       - label: Publish Date
         name: date
         widget: datetime
+        format: 'YYYY-MM-DDTHH:mm'
       - label: Description
         name: description
         widget: text

--- a/dev-test/backends/github/config.yml
+++ b/dev-test/backends/github/config.yml
@@ -28,6 +28,7 @@ collections:
       - label: Publish Date
         name: date
         widget: datetime
+        format: 'YYYY-MM-DDTHH:mm'
       - label: Description
         name: description
         widget: text

--- a/dev-test/backends/gitlab/config.yml
+++ b/dev-test/backends/gitlab/config.yml
@@ -28,6 +28,7 @@ collections:
       - label: Publish Date
         name: date
         widget: datetime
+        format: 'YYYY-MM-DDTHH:mm'
       - label: Description
         name: description
         widget: text

--- a/dev-test/backends/proxy/config.yml
+++ b/dev-test/backends/proxy/config.yml
@@ -32,6 +32,7 @@ collections:
       - label: Publish Date
         name: date
         widget: datetime
+        format: 'YYYY-MM-DDTHH:mm'
       - label: Description
         name: description
         widget: text

--- a/packages/decap-cms-widget-datetime/src/DateTimeControl.js
+++ b/packages/decap-cms-widget-datetime/src/DateTimeControl.js
@@ -64,7 +64,7 @@ class DateTimeControl extends React.Component {
 
   getFormat() {
     const { field } = this.props;
-    const format = field?.get('format') || 'YYYY-MM-DDTHH:mm';
+    const format = field?.get('format') || 'YYYY-MM-DDTHH:mm:ss.SSS[Z]';
     const dateFormat = field?.get('date_format');
     const timeFormat = field?.get('time_format');
     let inputFormat = 'YYYY-MM-DDTHH:mm';


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

https://github.com/decaporg/decap-cms/pull/7091 unintentionally changed how the date format is saved to frontmatter by default
this PR should patch this

to avoid re-recording fixtures, I set the format in the config.yml for e2e tests

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**Checklist**

Please add a `x` inside each checkbox:

- [ ] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
