### PR TITLE
fix: fix formatInputValue ignoring format

### DIFF
--- a/packages/decap-cms-widget-datetime/src/DateTimeControl.js
+++ b/packages/decap-cms-widget-datetime/src/DateTimeControl.js
@@ -114,15 +114,9 @@ class DateTimeControl extends React.Component {
   formatInputValue(value) {
     if (value === '') return value;
     const { format, inputFormat } = this.getFormat();
-    let formattedValue = this.isUtc
-      ? dayjs.utc(value).format(inputFormat)
-      : dayjs(value).format(inputFormat);
-    if (!this.isValidDate(formattedValue)) {
-      formattedValue = this.isUtc
-        ? dayjs.utc(value, format).format(inputFormat)
-        : dayjs(value, format).format(inputFormat);
-    }
-    return formattedValue;
+    return this.isUtc
+      ? dayjs.utc(value, format).format(inputFormat)
+      : dayjs(value, format).format(inputFormat);
   }
 
   handleChange = datetime => {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

A fix for a bug that was introduced in https://github.com/decaporg/decap-cms/pull/7091

Should solve issue https://github.com/decaporg/decap-cms/issues/7166 

`format` prop was used only if the auto parser returned an invalid date, so dates like 1.4.2024 were parsed as 4.1.2024 as both options are valid dates

**Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**Checklist**

Please add a `x` inside each checkbox:

- [ ] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
