### PR TITLE
feat: nested fields and integer values for filter relation widget

### DIFF
--- a/packages/decap-cms-widget-relation/src/RelationControl.js
+++ b/packages/decap-cms-widget-relation/src/RelationControl.js
@@ -351,11 +351,19 @@ export default class RelationControl extends React.Component {
 
     const options = hits.reduce((acc, hit) => {
       if (
-        filters.every(
-          filter =>
-            Object.prototype.hasOwnProperty.call(hit.data, filter.field) &&
-            filter.values.includes(hit.data[filter.field]),
-        )
+        filters.every(filter => {
+          // check if the value for the (nested) filter field is in the filter values
+          const fieldKeys = filter.field.split('.');
+          let value = hit.data;
+          for (let i = 0; i < fieldKeys.length; i++) {
+            if (Object.prototype.hasOwnProperty.call(value, fieldKeys[i])) {
+              value = value[fieldKeys[i]];
+            } else {
+              return false;
+            }
+          }
+          return filter.values.includes(value);
+        })
       ) {
         const valuesPaths = stringTemplate.expandPath({ data: hit.data, path: valueField });
         for (let i = 0; i < valuesPaths.length; i++) {

--- a/packages/decap-cms-widget-relation/src/schema.js
+++ b/packages/decap-cms-widget-relation/src/schema.js
@@ -15,7 +15,7 @@ export default {
         type: 'object',
         properties: {
           field: { type: 'string' },
-          values: { type: 'array', minItems: 1, items: { type: ['string', 'boolean'] } },
+          values: { type: 'array', minItems: 1, items: { type: ['string', 'boolean', 'integer'] } },
         },
         required: ['field', 'values'],
       },


### PR DESCRIPTION
**Summary**

This PR for the relation widget adds functionality for nested fields in the filters and also allows integer types for the values in the filters. 
- Nested fields: it is now possible to have a filter like this: `filters: [ { field: 'deeply.nested.field', values: ['Some text'] } ]`
- Integer type: values can now also be integers (before only booleans and strings were allowed): `filters: [ { field: 'num', values: [1, 12, 20] } ]`

**Test plan**

I added a unit test for the nested fields and for the integer type.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
![IMG_0381](https://github.com/decaporg/decap-cms/assets/72915212/544e7d95-558b-4eda-b1cb-a9e64dd34c54)