### PR TITLE
chore: update readme

### DIFF
--- a/packages/decap-cms-app/README.md
+++ b/packages/decap-cms-app/README.md
@@ -17,8 +17,8 @@ Install via script tag:
 <!-- Excluding `doctype` and `head` but you should add them -->
 <body>
   <!-- Add these scripts to the bottom of the body -->
-  <script src="https://unpkg.com/react@^16/umd/react.production.min.js"></script>
-  <script src="https://unpkg.com/react-dom@^16/umd/react-dom.production.min.js"></script>
+  <script src="https://unpkg.com/react@^18/umd/react.production.min.js"></script>
+  <script src="https://unpkg.com/react-dom@^18/umd/react-dom.production.min.js"></script>
   <script src="https://unpkg.com/decap-cms-app/dist/decap-cms-app.js"></script>
   
   <!-- Initialize the CMS -->


### PR DESCRIPTION
update react and react-dom version from 16 to 18

related issue:
https://github.com/decaporg/gatsby-plugin-decap-cms/issues/4

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
The readme was outdated. The correct react versions are 18

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Manually initializing decap threw: `i.createRoot is not a function`

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
