### PR TITLE
fix: change EditorToolbar position style

### DIFF
--- a/packages/decap-cms-core/src/components/Editor/EditorToolbar.js
+++ b/packages/decap-cms-core/src/components/Editor/EditorToolbar.js
@@ -85,7 +85,7 @@ const DropdownButton = styled(StyledDropdownButton)`
 const ToolbarContainer = styled.div`
   box-shadow: 0 2px 6px 0 rgba(68, 74, 87, 0.05), 0 1px 3px 0 rgba(68, 74, 87, 0.1),
     0 2px 54px rgba(0, 0, 0, 0.1);
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   width: 100%;

--- a/packages/decap-cms-core/src/components/Editor/__tests__/__snapshots__/EditorToolbar.spec.js.snap
+++ b/packages/decap-cms-core/src/components/Editor/__tests__/__snapshots__/EditorToolbar.spec.js.snap
@@ -4,7 +4,7 @@ exports[`EditorToolbar should render normal save button 1`] = `
 <DocumentFragment>
   .emotion-0 {
   box-shadow: 0 2px 6px 0 rgba(68, 74, 87, 0.05),0 1px 3px 0 rgba(68, 74, 87, 0.1),0 2px 54px rgba(0, 0, 0, 0.1);
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   width: 100%;
@@ -260,7 +260,7 @@ exports[`EditorToolbar should render normal save button 2`] = `
 <DocumentFragment>
   .emotion-0 {
   box-shadow: 0 2px 6px 0 rgba(68, 74, 87, 0.05),0 1px 3px 0 rgba(68, 74, 87, 0.1),0 2px 54px rgba(0, 0, 0, 0.1);
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   width: 100%;
@@ -516,7 +516,7 @@ exports[`EditorToolbar should render with default props 1`] = `
 <DocumentFragment>
   .emotion-0 {
   box-shadow: 0 2px 6px 0 rgba(68, 74, 87, 0.05),0 1px 3px 0 rgba(68, 74, 87, 0.1),0 2px 54px rgba(0, 0, 0, 0.1);
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   width: 100%;
@@ -731,7 +731,7 @@ exports[`EditorToolbar should render with status=draft,useOpenAuthoring=false 1`
 <DocumentFragment>
   .emotion-0 {
   box-shadow: 0 2px 6px 0 rgba(68, 74, 87, 0.05),0 1px 3px 0 rgba(68, 74, 87, 0.1),0 2px 54px rgba(0, 0, 0, 0.1);
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   width: 100%;
@@ -1021,7 +1021,7 @@ exports[`EditorToolbar should render with status=draft,useOpenAuthoring=true 1`]
 <DocumentFragment>
   .emotion-0 {
   box-shadow: 0 2px 6px 0 rgba(68, 74, 87, 0.05),0 1px 3px 0 rgba(68, 74, 87, 0.1),0 2px 54px rgba(0, 0, 0, 0.1);
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   width: 100%;
@@ -1372,7 +1372,7 @@ exports[`EditorToolbar should render with status=pending_publish,useOpenAuthorin
 <DocumentFragment>
   .emotion-0 {
   box-shadow: 0 2px 6px 0 rgba(68, 74, 87, 0.05),0 1px 3px 0 rgba(68, 74, 87, 0.1),0 2px 54px rgba(0, 0, 0, 0.1);
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   width: 100%;
@@ -1662,7 +1662,7 @@ exports[`EditorToolbar should render with status=pending_publish,useOpenAuthorin
 <DocumentFragment>
   .emotion-0 {
   box-shadow: 0 2px 6px 0 rgba(68, 74, 87, 0.05),0 1px 3px 0 rgba(68, 74, 87, 0.1),0 2px 54px rgba(0, 0, 0, 0.1);
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   width: 100%;
@@ -1990,7 +1990,7 @@ exports[`EditorToolbar should render with status=pending_review,useOpenAuthoring
 <DocumentFragment>
   .emotion-0 {
   box-shadow: 0 2px 6px 0 rgba(68, 74, 87, 0.05),0 1px 3px 0 rgba(68, 74, 87, 0.1),0 2px 54px rgba(0, 0, 0, 0.1);
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   width: 100%;
@@ -2280,7 +2280,7 @@ exports[`EditorToolbar should render with status=pending_review,useOpenAuthoring
 <DocumentFragment>
   .emotion-0 {
   box-shadow: 0 2px 6px 0 rgba(68, 74, 87, 0.05),0 1px 3px 0 rgba(68, 74, 87, 0.1),0 2px 54px rgba(0, 0, 0, 0.1);
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   width: 100%;
@@ -2631,7 +2631,7 @@ exports[`EditorToolbar should render with workflow controls hasUnpublishedChange
 <DocumentFragment>
   .emotion-0 {
   box-shadow: 0 2px 6px 0 rgba(68, 74, 87, 0.05),0 1px 3px 0 rgba(68, 74, 87, 0.1),0 2px 54px rgba(0, 0, 0, 0.1);
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   width: 100%;
@@ -2851,7 +2851,7 @@ exports[`EditorToolbar should render with workflow controls hasUnpublishedChange
 <DocumentFragment>
   .emotion-0 {
   box-shadow: 0 2px 6px 0 rgba(68, 74, 87, 0.05),0 1px 3px 0 rgba(68, 74, 87, 0.1),0 2px 54px rgba(0, 0, 0, 0.1);
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   width: 100%;
@@ -3041,7 +3041,7 @@ exports[`EditorToolbar should render with workflow controls hasUnpublishedChange
 <DocumentFragment>
   .emotion-0 {
   box-shadow: 0 2px 6px 0 rgba(68, 74, 87, 0.05),0 1px 3px 0 rgba(68, 74, 87, 0.1),0 2px 54px rgba(0, 0, 0, 0.1);
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   width: 100%;
@@ -3261,7 +3261,7 @@ exports[`EditorToolbar should render with workflow controls hasUnpublishedChange
 <DocumentFragment>
   .emotion-0 {
   box-shadow: 0 2px 6px 0 rgba(68, 74, 87, 0.05),0 1px 3px 0 rgba(68, 74, 87, 0.1),0 2px 54px rgba(0, 0, 0, 0.1);
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   width: 100%;
@@ -3481,7 +3481,7 @@ exports[`EditorToolbar should render with workflow controls hasUnpublishedChange
 <DocumentFragment>
   .emotion-0 {
   box-shadow: 0 2px 6px 0 rgba(68, 74, 87, 0.05),0 1px 3px 0 rgba(68, 74, 87, 0.1),0 2px 54px rgba(0, 0, 0, 0.1);
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   width: 100%;
@@ -3701,7 +3701,7 @@ exports[`EditorToolbar should render with workflow controls hasUnpublishedChange
 <DocumentFragment>
   .emotion-0 {
   box-shadow: 0 2px 6px 0 rgba(68, 74, 87, 0.05),0 1px 3px 0 rgba(68, 74, 87, 0.1),0 2px 54px rgba(0, 0, 0, 0.1);
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   width: 100%;


### PR DESCRIPTION
Changed ToolbarContainer's position element to be absolute - #7197

Fixes #7197 

**Summary**

I was following the docs and wanted to mount decap inside of a div on my page, this worked good on the landing page of decap but did not work once I was on an editing page. The editor toolbar had a fixed position to the top so it would come out of my div and cover the custom header that I had made.

**Test plan**

I ran the tests using npm, at first they failed since the editor toolbar did not match the snapshot but since changing the component was what was intended, I updated the snapshot and the tests passed. (there was a warning that was also present before my change)

Screenshots before my change (I have decap mounted inside of a div that only covers 90% width of the page and has a header and footer above and below)
Before Change (ToolbarContainer has a position of fixed)
![Screenshot 2024-05-05 231725](https://github.com/decaporg/decap-cms/assets/62771166/4941ed31-1b6e-4108-ace9-63e1905f73b5)
AfterChange (ToolbarContainer has a position of absolute)
![Screenshot 2024-05-05 231122](https://github.com/decaporg/decap-cms/assets/62771166/a3f99505-39f5-4b09-8e36-0a8ab17f966a)


**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
![bean](https://github.com/decaporg/decap-cms/assets/62771166/4fa97224-c465-4e39-a48d-4e5eb67a42a7)
