### PR TITLE
fix: change AppHeaderButton style fixing #7208

### DIFF
--- a/packages/decap-cms-core/src/components/App/Header.js
+++ b/packages/decap-cms-core/src/components/App/Header.js
@@ -71,7 +71,7 @@ const AppHeaderButton = styled.button`
 
   &:hover,
   &:active,
-  &:focus {
+  &:focus-visible {
     ${styles.buttonActive};
 
     ${Icon} {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->
Fixes #7208 by changing style of AppHeaderButton to use :focus-visible instead of :focus.
This was noticed when closing the media library the "Media" header link would remain blue until anything else was interacted with.

**Test plan**

Passed all tests after running npm run test. Everything still functions identically when navigating the site with a keyboard as well as a mouse.
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**Checklist**

Please add a `x` inside each checkbox:

- [ x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
![DSC00002](https://github.com/decaporg/decap-cms/assets/62771166/8efb36fd-17ac-465a-9e33-b77adfdb92f7)

