### PR TITLE
fix: display custom logo when using a proxy server

### DIFF
--- a/packages/decap-cms-backend-proxy/src/AuthenticationPage.js
+++ b/packages/decap-cms-backend-proxy/src/AuthenticationPage.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { Icon, buttons, shadows, GoBackButton } from 'decap-cms-ui-default';
+import { Icon, buttons, shadows, GoBackButton, renderPageLogo } from 'decap-cms-ui-default';
 
 const StyledAuthenticationPage = styled.section`
   display: flex;
@@ -9,11 +9,6 @@ const StyledAuthenticationPage = styled.section`
   align-items: center;
   justify-content: center;
   height: 100vh;
-`;
-
-const PageLogoIcon = styled(Icon)`
-  color: #c4c6d2;
-  margin-top: -300px;
 `;
 
 const LoginButton = styled.button`
@@ -51,7 +46,7 @@ export default class AuthenticationPage extends React.Component {
 
     return (
       <StyledAuthenticationPage>
-        <PageLogoIcon size="300px" type="decap-cms" />
+        {renderPageLogo(config.logo_url)}
         <LoginButton disabled={inProgress} onClick={this.handleLogin}>
           {inProgress ? t('auth.loggingIn') : t('auth.login')}
         </LoginButton>

--- a/packages/decap-cms-ui-default/src/AuthenticationPage.js
+++ b/packages/decap-cms-ui-default/src/AuthenticationPage.js
@@ -111,4 +111,4 @@ AuthenticationPage.propTypes = {
   t: PropTypes.func.isRequired,
 };
 
-export default AuthenticationPage;
+export { AuthenticationPage as default, renderPageLogo };

--- a/packages/decap-cms-ui-default/src/index.js
+++ b/packages/decap-cms-ui-default/src/index.js
@@ -10,7 +10,7 @@ import Loader from './Loader';
 import FieldLabel from './FieldLabel';
 import IconButton from './IconButton';
 import Toggle, { ToggleContainer, ToggleBackground, ToggleHandle } from './Toggle';
-import AuthenticationPage from './AuthenticationPage';
+import AuthenticationPage, { renderPageLogo } from './AuthenticationPage';
 import WidgetPreviewContainer from './WidgetPreviewContainer';
 import ObjectWidgetTopBar from './ObjectWidgetTopBar';
 import GoBackButton from './GoBackButton';
@@ -63,6 +63,7 @@ export const DecapCmsUiDefault = {
   zIndex,
   reactSelectStyles,
   GlobalStyles,
+  renderPageLogo,
 };
 export {
   Dropdown,
@@ -97,4 +98,5 @@ export {
   reactSelectStyles,
   GlobalStyles,
   GoBackButton,
+  renderPageLogo,
 };


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**
fixes #5752 

Bug occurred because the  `decap-cms-backend-proxy` package uses a different authentication page. Yet, this page didn't reuse `renderPageLogo` function that is defined in `decap-cms-ui-default`, which allows the display of a custom logo.
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**

1. Run `npm run decap-server`
2. Add `logo_url: YOUR_LOGO_URL` to `config.yml`

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
