### PR TITLE
Fix login with Gitlab (change API `Authorization` header "token" → "Bearer")

### DIFF
--- a/packages/decap-cms-lib-util/src/API.ts
+++ b/packages/decap-cms-lib-util/src/API.ts
@@ -182,7 +182,7 @@ async function constructRequestHeaders(headerConfig: HeaderConfig) {
   const { token, headers } = headerConfig;
   const baseHeaders: HeaderObj = { 'Content-Type': 'application/json; charset=utf-8', ...headers };
   if (token) {
-    baseHeaders['Authorization'] = `token ${token}`;
+    baseHeaders['Authorization'] = `Bearer ${token}`;
   }
   return Promise.resolve(baseHeaders);
 }


### PR DESCRIPTION
The authorization type "Bearer" is more widely recognized than "token". E.g. Gitlab requires that you use "Bearer".

Github mentions that it accepts both "token" and "Bearer": https://docs.github.com/en/rest/authentication/authenticating-to-the-rest-api?apiVersion=2022-11-28#about-authentication

Gitlab seems to require the use of "Bearer", which was apparently the cause of #7172: https://github.com/decaporg/decap-cms/issues/7172#issuecomment-2184138768 (thanks to @b-xb for digging into this)

See also: https://github.com/decaporg/decap-cms/pull/5844#discussion_r1658974332

Fixes #7172.


**Summary**

Gitlab login is broken in current versions: #7172

**Test plan**


**Checklist**

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
![](https://github.com/decaporg/decap-cms/assets/3904348/5a5056f1-1186-4517-9cf7-ef396ef1cc20)

