### PR TITLE
fix: improve field error position

### DIFF
--- a/packages/decap-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/decap-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -81,12 +81,9 @@ const ControlErrorsList = styled.ul`
   list-style-type: none;
   font-size: 12px;
   color: ${colors.errorText};
-  margin-bottom: 5px;
+  margin-bottom: 8px;
   text-align: right;
-  text-transform: uppercase;
-  position: relative;
   font-weight: 600;
-  top: 20px;
 `;
 
 export const ControlHint = styled.p`


### PR DESCRIPTION
Improves position of the field error so that it doesn't hide behind label.

I also aligned text to the left.

This is the updated look:

![Screenshot 2024-08-02 at 13 34 25](https://github.com/user-attachments/assets/281003a9-b541-4e0a-8aa8-a358dd30c5f1)

Closes #1654