### PR TITLE
fix: remove attempt to get a more comprehensive error

### DIFF
--- a/packages/decap-cms-core/src/backend.ts
+++ b/packages/decap-cms-core/src/backend.ts
@@ -1,4 +1,4 @@
-import { attempt, flatten, isError, uniq, trim, sortBy, get, set } from 'lodash';
+import { flatten, isError, uniq, trim, sortBy, get, set } from 'lodash';
 import { List, fromJS, Set } from 'immutable';
 import * as fuzzy from 'fuzzy';
 import {
@@ -869,7 +869,7 @@ export class Backend {
     return (entry: EntryValue): EntryValue => {
       const format = resolveFormat(collection, entry);
       if (entry && entry.raw !== undefined) {
-        const data = (format && attempt(format.fromFile.bind(format, entry.raw))) || {};
+        const data = (format && format.fromFile.bind(format, entry.raw)()) || {};
         if (isError(data)) console.error(data);
         return Object.assign(entry, { data: isError(data) ? {} : data });
       }


### PR DESCRIPTION
Closes #7262

`attempt` was used to better handle the function, but it obtused the error so it was not clear which frontamtter field was duplicated.