### PR TITLE
fix: trigger change if default is {{now}}

### DIFF
--- a/packages/decap-cms-widget-datetime/src/DateTimeControl.js
+++ b/packages/decap-cms-widget-datetime/src/DateTimeControl.js
@@ -62,6 +62,13 @@ class DateTimeControl extends React.Component {
     isDisabled: false,
   };
 
+  componentDidMount() {
+    const { value } = this.props;
+    if (value === '{{now}}') {
+      this.handleChange(this.getNow());
+    }
+  }
+
   isUtc = this.props.field.get('picker_utc') || false;
 
   escapeZ(str) {
@@ -122,10 +129,6 @@ class DateTimeControl extends React.Component {
   formatInputValue(value) {
     if (value === '') return value;
     const { format, inputFormat } = this.getFormat();
-
-    if (typeof value === 'string' && value?.replace(/\s+/g, '') === '{{now}}') {
-      return this.getNow();
-    }
 
     const inputValue = this.isUtc
       ? dayjs.utc(value, format).format(inputFormat)


### PR DESCRIPTION
Closes #7271

The value was set in the UI, but handleChange never triggerred, so it never rewrote `"{{now}}"` with the current date. This PR moves the check into the mount hook and triggers `handleChange`, so that correct value is saved.