### PR TITLE
fix: summary string transformations format (#7221)

### DIFF
--- a/packages/decap-cms-lib-widgets/src/stringTemplate.ts
+++ b/packages/decap-cms-lib-widgets/src/stringTemplate.ts
@@ -175,8 +175,12 @@ export function compileStringTemplate(
     RegExp(templateVariablePattern, 'g'),
     (_full, key: string, _part, filter: string) => {
       let replacement;
-      key = key.trim();
-      filter = filter.trim();
+      if (key) {
+        key = key.trim();
+      }
+      if (filter) {
+        filter = filter.trim();
+      }
       const explicitFieldReplacement = getExplicitFieldReplacement(key, data);
 
       if (explicitFieldReplacement) {

--- a/packages/decap-cms-lib-widgets/src/stringTemplate.ts
+++ b/packages/decap-cms-lib-widgets/src/stringTemplate.ts
@@ -36,8 +36,8 @@ const filters = [
 ];
 
 const FIELD_PREFIX = 'fields.';
-const templateContentPattern = '([^}{|]+)';
-const filterPattern = '( \\| ([^}{]+))?';
+const templateContentPattern = ' *([^}{| ]+)';
+const filterPattern = '( \\| ([^}{]+?))? *';
 const templateVariablePattern = `{{${templateContentPattern}${filterPattern}}}`;
 
 // prepends a Zero if the date has only 1 digit
@@ -175,12 +175,6 @@ export function compileStringTemplate(
     RegExp(templateVariablePattern, 'g'),
     (_full, key: string, _part, filter: string) => {
       let replacement;
-      if (key) {
-        key = key.trim();
-      }
-      if (filter) {
-        filter = filter.trim();
-      }
       const explicitFieldReplacement = getExplicitFieldReplacement(key, data);
 
       if (explicitFieldReplacement) {

--- a/packages/decap-cms-lib-widgets/src/stringTemplate.ts
+++ b/packages/decap-cms-lib-widgets/src/stringTemplate.ts
@@ -175,6 +175,8 @@ export function compileStringTemplate(
     RegExp(templateVariablePattern, 'g'),
     (_full, key: string, _part, filter: string) => {
       let replacement;
+      key = key.trim();
+      filter = filter.trim();
       const explicitFieldReplacement = getExplicitFieldReplacement(key, data);
 
       if (explicitFieldReplacement) {


### PR DESCRIPTION
**Summary**

allow empty spaces in Summary String Transformations
closes #7221 

**Test plan**
`summary: "{{ title | upper }} / {{ title | lower }} / {{ title | truncate(1) }} / {{ nonexistant | default('Hello') }} / {{ mytruth | ternary('Yep','Nope') }} / {{ date | date('YYYY') }}"`

BEFORE: 
`/ / / / / `

AFTER:
`TITLE / title / t... / Hello / Yep / 2024`

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
![370303722_3538721283063071_655819586224672097_n](https://github.com/user-attachments/assets/658d944e-33d5-4452-8670-e1061c7eddee)
