### PR TITLE
missing npm script test:all

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "clean": "rimraf \"packages/*/dist\" dev-test/dist \"packages/*/node_modules\"",
     "reset": "npm run clean",
     "test": "npm run lint && npm run type-check && npm run test:unit",
+    "test:all": "npm run test && npm run test:e2e",
     "test:ci": "npm run lint-quiet && npm run type-check && npm run test:unit",
     "test:unit": "cross-env NODE_ENV=test jest --no-cache",
     "test:e2e": "npm run build:demo && npm run test:e2e:run",


### PR DESCRIPTION
**Summary**

closes #7201

**Test plan**

running `npm run test:all` runs linting, Jest, and Cypress tests

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
![image](https://github.com/user-attachments/assets/297cdad2-a1e0-4e90-b5f0-0dbd1d70103e)
