### PR TITLE
fix(object-widget): highlight nested validation errors

### DIFF
--- a/packages/decap-cms-widget-object/src/ObjectControl.js
+++ b/packages/decap-cms-widget-object/src/ObjectControl.js
@@ -89,6 +89,7 @@ export default class ObjectControl extends React.Component {
       isFieldHidden,
       locale,
       collapsed,
+      forID,
     } = this.props;
 
     if (field.get('widget') === 'hidden') {
@@ -112,7 +113,7 @@ export default class ObjectControl extends React.Component {
         onValidate={onValidateObject}
         processControlRef={controlRef && controlRef.bind(this)}
         controlRef={controlRef}
-        parentIds={parentIds}
+        parentIds={[...parentIds, forID]}
         isDisabled={isDuplicate}
         isHidden={isHidden}
         isFieldDuplicate={isFieldDuplicate}


### PR DESCRIPTION
**Summary**

When building nested controls for fields in an object widget, ensure the object's ID is passed through as a 'parent' so that errors in nested fields can be linked to the parent.

This ensures that a validation error on a field within an object will "bubble up" and show an error on a collapsed object's control in the editor, helping users to identify where there are validation errors.

**Test plan**

1. Open the demo site
2. Create a new Kitchen Sink collection entry
3. Enter something for the title, click Save
4. Scroll down to check the "Object" editor control and check if it's highlighted red

Before:

![image](https://github.com/user-attachments/assets/903fd140-4c00-4731-892d-ebb77ae14614)

After:

![image](https://github.com/user-attachments/assets/b52666e1-148c-44b8-92ce-37f27cffc1b5)

**Checklist**

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).