### PR TITLE
add special chars to prepareSlug

### DIFF
--- a/packages/decap-cms-core/src/lib/__tests__/formatters.spec.js
+++ b/packages/decap-cms-core/src/lib/__tests__/formatters.spec.js
@@ -265,6 +265,34 @@ describe('formatters', () => {
     it('should replace periods with slashes', () => {
       expect(prepareSlug(`sl.ug`)).toBe('sl-ug');
     });
+
+    it('should replace á,à or ä to a', () => {
+      expect(prepareSlug(`áàä`)).toBe('aaa');
+    });
+
+    it('should replace é,è or ë to e', () => {
+      expect(prepareSlug(`éèë`)).toBe('eee');
+    });
+
+    it('should replace í, ì or ï to i', () => {
+      expect(prepareSlug(`íìï`)).toBe('iii');
+    });
+
+    it('should replace ó, ò or ö to o', () => {
+      expect(prepareSlug(`óòö`)).toBe('ooo');
+    });
+
+    it('should replace ú,ù or ü to u', () => {
+      expect(prepareSlug(`úùü`)).toBe('uuu');
+    });
+
+    it('should replace ç to c', () => {
+      expect(prepareSlug(`ç`)).toBe('c');
+    });
+
+    it('should remove ’', () => {
+      expect(prepareSlug(`sl’ug`)).toBe('slug');
+    });
   });
 
   const slugConfig = {

--- a/packages/decap-cms-core/src/lib/formatters.ts
+++ b/packages/decap-cms-core/src/lib/formatters.ts
@@ -101,6 +101,27 @@ export function prepareSlug(slug: string) {
 
       // Replace periods with dashes.
       .replace(/[.]/g, '-')
+
+      // Replace á,à or ä to a
+      .replace(/[áàä]/g, 'a')
+
+      // Replace é,è or ë to e
+      .replace(/[éèë]/g, 'e')
+
+      // Replace í, ì or ï to i
+      .replace(/[íìï]/g, 'i')
+
+      // Replace ó, ò or ö to o
+      .replace(/[óòö]/g, 'o')
+
+      // Replace ú,ù or ü to u
+      .replace(/[úùü]/g, 'u')
+
+      // Replace ç to c
+      .replace(/[ç]/g, 'c')
+
+      // Remove ’
+      .replace(/[’]/g, '')
   );
 }
 


### PR DESCRIPTION
**Summary**
This is my first pull request. I've read the contribution guidelines and I think I did everything.

When creating a collection file with a path like "{{title}}/{{slug}}" when the title contains characters like ç, é, ò... the file was created with this character in it's file name.

This file names were causing me problems with `hugo serve`, files with this characters in the name were not updated when changed, even hugo not showing any error.

**Test plan**

tests created and executed `npm run test`.

```shell
Test Suites: 1 skipped, 80 passed, 80 of 81 total
Tests:       652 skipped, 1009 passed, 1661 total
Snapshots:   110 passed, 110 total
Time:        15.253 s
Ran all test suites.
``` 

**Checklist**

- [ x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).
