### PR TITLE
fix(build): Fix ESM output (#7357)

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -42,7 +42,7 @@ const svgo = {
 function presets() {
   return [
     '@babel/preset-react',
-    '@babel/preset-env',
+    ['@babel/preset-env', isESM ? { modules: false } : {}],
     [
       '@emotion/babel-preset-css-prop',
       {

--- a/nx.json
+++ b/nx.json
@@ -1,10 +1,12 @@
 {
   "targetDefaults": {
     "build:esm": {
-      "cache": true
+      "cache": true,
+      "dependsOn": ["^build:esm"]
     },
     "build": {
-      "cache": true
+      "cache": true,
+      "dependsOn": ["^build"]
     }
   },
   "namedInputs": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build-preview": "npm run build && nx run decap-cms:build-preview --output-style=stream",
     "type-check": "tsc --noEmit",
     "type-check:watch": "npm run type-check -- --watch",
-    "clean": "rimraf \"packages/*/dist\" dev-test/dist \"packages/*/node_modules\"",
+    "clean": "rimraf \"packages/*/dist\" dev-test/dist \"packages/*/node_modules\" \".nx/cache\"",
     "reset": "npm run clean",
     "test": "npm run lint && npm run type-check && npm run test:unit",
     "test:all": "npm run test && npm run test:e2e",

--- a/packages/decap-cms/src/extensions.js
+++ b/packages/decap-cms/src/extensions.js
@@ -1,4 +1,4 @@
-import { DecapCmsApp as CMS } from 'decap-cms-app/dist/esm';
+import { DecapCmsApp as CMS } from 'decap-cms-app';
 // Media libraries
 import uploadcare from 'decap-cms-media-library-uploadcare';
 import cloudinary from 'decap-cms-media-library-cloudinary';

--- a/packages/decap-cms/src/index.js
+++ b/packages/decap-cms/src/index.js
@@ -1,6 +1,6 @@
 import createReactClass from 'create-react-class';
 import React from 'react';
-import { DecapCmsApp as CMS } from 'decap-cms-app/dist/esm';
+import { DecapCmsApp as CMS } from 'decap-cms-app';
 import './extensions';
 
 /**


### PR DESCRIPTION
**Summary**

This PR fixes two related issues discovered while working on ESM builds:

1. ESM builds incorrectly output CommonJS format despite being in `dist/esm` directories. This happens because Babel's preset-env transforms ES modules to CommonJS by default. The issue can be seen in [decap-cms-core's ESM build](https://unpkg.com/browse/decap-cms-core@3.5.0/dist/esm/index.js).

2. Build dependencies are not properly configured in Nx, causing builds to fail with empty cache as packages are built in parallel without respecting dependencies.

Changes:
- Configure Babel to preserve ES modules by setting `modules: false` for ESM builds
- Add proper build dependencies in `nx.json` to ensure correct build order
- Remove direct imports from `dist/esm` in favor of proper package entry points

Fixes #7357

**Test plan**

1. Clean the workspace:
```
bash
npm run clean
```

2. Build directly with nx (this would fail before the fix):
```bash
NX_NO_CLOUD=true npx nx run decap-cms:build
```

3. Verify ESM output format in any package's `dist/esm/index.js`:
```js
// Should see ES module syntax:
export default DecapCmsCore;
// Instead of CommonJS:
exports.default = exports.DecapCmsCore = void 0;
```

**Checklist**

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

**A picture of a cute animal**
![xmas-cat](https://github.com/user-attachments/assets/e2e01f22-27ad-4b75-b345-c11fae7c47df)

