### PR TITLE
fix(ObjectControl): hotfix nested object validation

### DIFF
--- a/packages/decap-cms-widget-object/src/ObjectControl.js
+++ b/packages/decap-cms-widget-object/src/ObjectControl.js
@@ -79,7 +79,12 @@ export default class ObjectControl extends React.Component {
       if (field.get('widget') === 'hidden') return;
       const name = field.get('name');
       const control = this.childRefs[name];
-      control?.validate?.();
+
+      if (control?.innerWrappedControl?.validate) {
+        control.innerWrappedControl.validate();
+      } else {
+        control?.validate?.();
+      }
     });
   };
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

This a quick patch for https://github.com/decaporg/decap-cms/issues/7383 that happened after the validation rework in https://github.com/decaporg/decap-cms/pull/7374

I have tested against most of the cases that I could think of and it seems to be ok.

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
This is the config that I tested with, changing required on/off and trying multiple nested depths
```
{name: pageHero, label: Page hero, widget: object, collapsed: true, summary: '{{fields.title}}', fields: [
      {name: title, widget: string, i18n: true, required: false, hint: 'if empty, page title will be used'},
      {name: description, widget: string, i18n: true, required: false, hint: 'if empty, page description will be used'},
      {name: button, widget: object, i18n: true, fields: [
        {name: text, widget: string, i18n: true, required: false},
        {name: href, widget: string, i18n: true, required: false},
      ]},
    ]}
```

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
No time for the cute picture this time 
