### PR TITLE
Fix default datetime widget format

### DIFF
--- a/packages/decap-cms-widget-datetime/src/DateTimeControl.js
+++ b/packages/decap-cms-widget-datetime/src/DateTimeControl.js
@@ -82,7 +82,7 @@ class DateTimeControl extends React.Component {
     const { field } = this.props;
     let inputType = 'datetime-local';
     let inputFormat = 'YYYY-MM-DDTHH:mm';
-    let format = 'YYYY-MM-DDTHH:mm:ss.SSS[Z]';
+    let format = `YYYY-MM-DDTHH:mm:ss.SSS${this.isUtc ? '[Z]' : 'Z'}`;
     let userFormat = field?.get('format');
     let dateFormat = field?.get('date_format');
     let timeFormat = field?.get('time_format');

--- a/packages/decap-cms-widget-datetime/src/__tests__/DateTimeControl.spec.js
+++ b/packages/decap-cms-widget-datetime/src/__tests__/DateTimeControl.spec.js
@@ -35,8 +35,16 @@ function setup(propsOverrides = {}) {
 }
 
 describe('DateTimeControl', () => {
+  const mockDate = '2025-01-01T12:00:00.000Z';
+
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(mockDate));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   test('renders the component with input, now button, and clear button', () => {
@@ -56,5 +64,27 @@ describe('DateTimeControl', () => {
     const { clearButton, props } = setup({ value: '1970-01-01' });
     fireEvent.click(clearButton);
     expect(props.onChange).toHaveBeenCalledWith('');
+  });
+
+  test('sets value in custom format (local timezone) when input value changes', () => {
+    const { input, props } = setup({ field: new Map() })
+
+    const testDate = '2024-03-15T10:30:00';
+
+    fireEvent.change(input, { target: { value: testDate } });
+
+    const expectedValue = dayjs(testDate).format('YYYY-MM-DDTHH:mm:ss.SSSZ');
+    expect(props.onChange).toHaveBeenCalledWith(expectedValue);
+  });
+
+  test('sets value in custom format (UTC) when input value changes', () => {
+    const { input, props } = setup({ field: new Map([['picker_utc', true]]) });
+
+    const testDate = '2024-03-15T10:30:00';
+
+    fireEvent.change(input, { target: { value: testDate } });
+
+    const expectedValue = dayjs(testDate).format('YYYY-MM-DDTHH:mm:ss.SSS[Z]');
+    expect(props.onChange).toHaveBeenCalledWith(expectedValue);
   });
 });


### PR DESCRIPTION
### **Summary**

Fix the issue described on https://github.com/decaporg/decap-cms/issues/7319

### Problem
When formatting dates, we currently use the format `'YYYY-MM-DDTHH:mm:ss.SSS[Z]'` by default. This format always includes a literal 'Z' timezone indicator (due to the escaped `[Z]`) regardless of the user's actual timezone setting. This creates confusion because:

1. Users who haven't explicitly set `utc` format see their local timezone in the widget but the data is actually stored in UTC (due to the forced 'Z' suffix)
2. This mismatch between display and storage timezone can lead to unexpected behavior and data inconsistencies

### Solution
Modified the default date formatting to only append the escaped UTC indicator ('[Z]') when `picker_utc` is explicitly set to `true`. This ensures that:

- Dates are stored with the correct timezone information based on user settings
- The widget's display accurately reflects how the date will be stored
- DayJS can properly handle timezone conversions based on actual user preferences

## Technical Details
- Previous format (always): `'YYYY-MM-DDTHH:mm:ss.SSS[Z]'`
- New format:
  - When `picker_utc: true`: `'YYYY-MM-DDTHH:mm:ss.SSS[Z]'`
  - When `picker_utc: false`: `'YYYY-MM-DDTHH:mm:ss.SSSZ'` (preserves local timezone)



**Test plan**

Added [tests](https://github.com/decaporg/decap-cms/blob/main/packages/decap-cms-widget-datetime/src/__tests__/DateTimeControl.spec.js) to check the date widget works as expected.

To run the tests:
```bash
NODE_ENV=test npx jest --no-cache packages/decap-cms-widget-datetime/src/__tests__/DateTimeControl.spec.js
```

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).