### PR TITLE
fix(#7375): fix dependency issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10460,13 +10460,14 @@
       }
     },
     "node_modules/clean-stack": {
-      "version": "4.2.0",
-      "license": "MIT",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.2.0.tgz",
+      "integrity": "sha512-TyUIUJgdFnCISzG5zu3291TAsE77ddchd0bepon1VVQrKLGKFED4iXFEDQ24mIPdPBbyE16PK3F8MYE1CmcBEQ==",
       "dependencies": {
         "escape-string-regexp": "5.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -27143,14 +27144,15 @@
       }
     },
     "node_modules/react-scroll-sync": {
-      "version": "0.9.0",
-      "license": "MIT",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/react-scroll-sync/-/react-scroll-sync-0.11.2.tgz",
+      "integrity": "sha512-n7m+bbRTSWuczhKQf6Evvl7PFGkTt4RfP4bhyUtUyv6znovpybhAScQDdrFr9Jh280nG39x9AWMY8j477PHL1A==",
       "dependencies": {
         "prop-types": "^15.5.7"
       },
       "peerDependencies": {
-        "react": "0.14.x || 15.x || 16.x || 17.x",
-        "react-dom": "0.14.x || 15.x || 16.x || 17.x"
+        "react": "16.x || 17.x || 18.x",
+        "react-dom": "16.x || 17.x || 18.x"
       }
     },
     "node_modules/react-select": {
@@ -29014,7 +29016,6 @@
     },
     "node_modules/slate-hyperscript": {
       "version": "0.77.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-plain-object": "^5.0.0"
@@ -33428,7 +33429,7 @@
         "ajv": "8.12.0",
         "ajv-errors": "^3.0.0",
         "ajv-keywords": "^5.0.0",
-        "clean-stack": "^4.1.0",
+        "clean-stack": "^5.2.0",
         "copy-text-to-clipboard": "^3.0.0",
         "dayjs": "^1.11.10",
         "deepmerge": "^4.2.2",
@@ -33454,7 +33455,7 @@
         "react-polyglot": "^0.7.0",
         "react-redux": "^7.2.0",
         "react-router-dom": "^5.2.0",
-        "react-scroll-sync": "^0.9.0",
+        "react-scroll-sync": "^0.11.2",
         "react-split-pane": "^0.1.85",
         "react-toastify": "^9.1.1",
         "react-topbar-progress-indicator": "^4.0.0",
@@ -33768,6 +33769,7 @@
         "slate": "^0.91.1",
         "slate-base64-serializer": "^0.2.107",
         "slate-history": "^0.93.0",
+        "slate-hyperscript": "^0.77.0",
         "slate-plain-serializer": "^0.7.1",
         "slate-react": "^0.91.2",
         "slate-soft-break": "^0.9.0",
@@ -33777,8 +33779,7 @@
       },
       "devDependencies": {
         "commonmark": "^0.30.0",
-        "commonmark-spec": "^0.30.0",
-        "slate-hyperscript": "^0.77.0"
+        "commonmark-spec": "^0.30.0"
       },
       "peerDependencies": {
         "@emotion/react": "^11.11.1",

--- a/packages/decap-cms-core/package.json
+++ b/packages/decap-cms-core/package.json
@@ -30,7 +30,7 @@
     "ajv": "8.12.0",
     "ajv-errors": "^3.0.0",
     "ajv-keywords": "^5.0.0",
-    "clean-stack": "^4.1.0",
+    "clean-stack": "^5.2.0",
     "copy-text-to-clipboard": "^3.0.0",
     "dayjs": "^1.11.10",
     "deepmerge": "^4.2.2",

--- a/packages/decap-cms-core/package.json
+++ b/packages/decap-cms-core/package.json
@@ -56,7 +56,7 @@
     "react-polyglot": "^0.7.0",
     "react-redux": "^7.2.0",
     "react-router-dom": "^5.2.0",
-    "react-scroll-sync": "^0.9.0",
+    "react-scroll-sync": "^0.11.2",
     "react-split-pane": "^0.1.85",
     "react-toastify": "^9.1.1",
     "react-topbar-progress-indicator": "^4.0.0",

--- a/packages/decap-cms-widget-markdown/package.json
+++ b/packages/decap-cms-widget-markdown/package.json
@@ -37,6 +37,7 @@
     "slate": "^0.91.1",
     "slate-base64-serializer": "^0.2.107",
     "slate-history": "^0.93.0",
+    "slate-hyperscript": "^0.77.0",
     "slate-plain-serializer": "^0.7.1",
     "slate-react": "^0.91.2",
     "slate-soft-break": "^0.9.0",
@@ -57,7 +58,6 @@
   },
   "devDependencies": {
     "commonmark": "^0.30.0",
-    "commonmark-spec": "^0.30.0",
-    "slate-hyperscript": "^0.77.0"
+    "commonmark-spec": "^0.30.0"
   }
 }


### PR DESCRIPTION
**Summary**

This PR addresses several dependency-related issues identified in #7375:

1. Turns `slate-hyperscript` from a dev dependency into a runtime dependency of `decap-cms-widget-markdown`
2. Updates `clean-stack` to v5.2.0 in `decap-cms-core`
3. Updates `react-scroll-sync` to v0.11.2 in `decap-cms-core`

This PR _does not_ address the CSS import issue. Simply removing the imports would break the pre-build scripts, where these imports are resolved by webpack.

**Test plan**

Verified that the following issues are resolved:
- `slate-hyperscript` resolution error
- `clean-stack` browser compatibility error (`os is not defined`)
- React 19 compatibility error with `react-scroll-sync`

**Checklist**

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

**A picture of a cute animal**

🐼