### PR TITLE
Move polyfill resolution from webpack to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6982,6 +6982,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/iarna__toml": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/iarna__toml/-/iarna__toml-2.0.5.tgz",
+      "integrity": "sha512-I55y+SxI0ayM4MBU6yfGJGmi4wRll6wtSeKiFYAZj+Z5Q1DVbMgBSVDYY+xQZbjIlLs/pN4fidnvR8faDrmxPg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/is-hotkey": {
       "version": "0.1.8",
       "license": "MIT"
@@ -33485,6 +33494,7 @@
       },
       "devDependencies": {
         "@types/history": "^4.7.8",
+        "@types/iarna__toml": "^2.0.5",
         "@types/redux-mock-store": "^1.0.2",
         "@types/url-join": "^4.0.0",
         "redux-mock-store": "^1.5.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -25854,7 +25854,8 @@
     },
     "node_modules/path-browserify": {
       "version": "1.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -33257,6 +33258,7 @@
       "license": "MIT",
       "dependencies": {
         "js-base64": "^3.0.0",
+        "path-browserify": "^1.0.1",
         "semaphore": "^1.1.0"
       },
       "peerDependencies": {
@@ -33277,6 +33279,7 @@
       "dependencies": {
         "common-tags": "^1.8.0",
         "js-base64": "^3.0.0",
+        "path-browserify": "^1.0.1",
         "semaphore": "^1.1.0",
         "what-the-diff": "^0.6.0"
       },
@@ -33356,6 +33359,7 @@
         "graphql": "^15.0.0",
         "graphql-tag": "^2.10.1",
         "js-base64": "^3.0.0",
+        "path-browserify": "^1.0.1",
         "semaphore": "^1.1.0"
       },
       "peerDependencies": {
@@ -33378,6 +33382,7 @@
         "apollo-link-context": "^1.0.18",
         "apollo-link-http": "^1.5.15",
         "js-base64": "^3.0.0",
+        "path-browserify": "^1.0.1",
         "semaphore": "^1.1.0"
       },
       "peerDependencies": {
@@ -33407,6 +33412,9 @@
     "packages/decap-cms-backend-test": {
       "version": "3.1.3",
       "license": "MIT",
+      "dependencies": {
+        "path-browserify": "^1.0.1"
+      },
       "peerDependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
@@ -33441,6 +33449,7 @@
         "js-base64": "^3.0.0",
         "jwt-decode": "^3.0.0",
         "node-polyglot": "^2.3.0",
+        "path-browserify": "^1.0.1",
         "prop-types": "^15.7.2",
         "react": "^18.2.0",
         "react-dnd": "^14.0.0",
@@ -33584,7 +33593,8 @@
       "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
-        "dayjs": "^1.11.10"
+        "dayjs": "^1.11.10",
+        "path-browserify": "^1.0.1"
       },
       "peerDependencies": {
         "immutable": "^3.7.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7073,12 +7073,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
-      "dev": true
-    },
     "node_modules/@types/minimist": {
       "version": "1.2.4",
       "license": "MIT"
@@ -33288,6 +33282,7 @@
       "dependencies": {
         "common-tags": "^1.8.0",
         "js-base64": "^3.0.0",
+        "minimatch": "^7.0.0",
         "path-browserify": "^1.0.1",
         "semaphore": "^1.1.0",
         "what-the-diff": "^0.6.0"
@@ -33304,6 +33299,20 @@
         "react": "^18.2.0"
       }
     },
+    "packages/decap-cms-backend-bitbucket/node_modules/minimatch": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
+      "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "packages/decap-cms-backend-git-gateway": {
       "version": "3.2.2",
       "license": "MIT",
@@ -33311,10 +33320,7 @@
         "gotrue-js": "^0.9.24",
         "ini": "^2.0.0",
         "jwt-decode": "^3.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "devDependencies": {
-        "@types/minimatch": "^5.1.2"
+        "minimatch": "^7.0.0"
       },
       "peerDependencies": {
         "@emotion/react": "^11.11.1",
@@ -33335,6 +33341,20 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "packages/decap-cms-backend-git-gateway/node_modules/minimatch": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
+      "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/decap-cms-backend-gitea": {

--- a/packages/decap-cms-backend-azure/package.json
+++ b/packages/decap-cms-backend-azure/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "js-base64": "^3.0.0",
+    "path-browserify": "^1.0.1",
     "semaphore": "^1.1.0"
   },
   "peerDependencies": {
@@ -33,5 +34,8 @@
     "lodash": "^4.17.11",
     "prop-types": "^15.7.2",
     "react": "^18.2.0"
+  },
+  "browser": {
+    "path": "path-browserify"
   }
 }

--- a/packages/decap-cms-backend-bitbucket/package.json
+++ b/packages/decap-cms-backend-bitbucket/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "common-tags": "^1.8.0",
     "js-base64": "^3.0.0",
+    "minimatch": "^7.0.0",
     "path-browserify": "^1.0.1",
     "semaphore": "^1.1.0",
     "what-the-diff": "^0.6.0"

--- a/packages/decap-cms-backend-bitbucket/package.json
+++ b/packages/decap-cms-backend-bitbucket/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "common-tags": "^1.8.0",
     "js-base64": "^3.0.0",
+    "path-browserify": "^1.0.1",
     "semaphore": "^1.1.0",
     "what-the-diff": "^0.6.0"
   },
@@ -34,5 +35,8 @@
     "lodash": "^4.17.11",
     "prop-types": "^15.7.2",
     "react": "^18.2.0"
+  },
+  "browser": {
+    "path": "path-browserify"
   }
 }

--- a/packages/decap-cms-backend-git-gateway/package.json
+++ b/packages/decap-cms-backend-git-gateway/package.json
@@ -23,7 +23,7 @@
     "gotrue-js": "^0.9.24",
     "ini": "^2.0.0",
     "jwt-decode": "^3.0.0",
-    "minimatch": "^3.0.4"
+    "minimatch": "^7.0.0"
   },
   "peerDependencies": {
     "@emotion/react": "^11.11.1",
@@ -37,8 +37,5 @@
     "lodash": "^4.17.11",
     "prop-types": "^15.7.2",
     "react": "^18.2.0"
-  },
-  "devDependencies": {
-    "@types/minimatch": "^5.1.2"
   }
 }

--- a/packages/decap-cms-backend-github/package.json
+++ b/packages/decap-cms-backend-github/package.json
@@ -28,6 +28,7 @@
     "graphql": "^15.0.0",
     "graphql-tag": "^2.10.1",
     "js-base64": "^3.0.0",
+    "path-browserify": "^1.0.1",
     "semaphore": "^1.1.0"
   },
   "peerDependencies": {
@@ -39,5 +40,8 @@
     "lodash": "^4.17.11",
     "prop-types": "^15.7.2",
     "react": "^18.2.0"
+  },
+  "browser": {
+    "path": "path-browserify"
   }
 }

--- a/packages/decap-cms-backend-gitlab/package.json
+++ b/packages/decap-cms-backend-gitlab/package.json
@@ -24,6 +24,7 @@
     "apollo-link-context": "^1.0.18",
     "apollo-link-http": "^1.5.15",
     "js-base64": "^3.0.0",
+    "path-browserify": "^1.0.1",
     "semaphore": "^1.1.0"
   },
   "peerDependencies": {
@@ -36,5 +37,8 @@
     "lodash": "^4.17.11",
     "prop-types": "^15.7.2",
     "react": "^18.2.0"
+  },
+  "browser": {
+    "path": "path-browserify"
   }
 }

--- a/packages/decap-cms-backend-test/package.json
+++ b/packages/decap-cms-backend-test/package.json
@@ -17,6 +17,9 @@
     "build": "cross-env NODE_ENV=production webpack",
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore \"**/__tests__\" --root-mode upward --extensions \".js,.jsx,.ts,.tsx\""
   },
+  "dependencies": {
+    "path-browserify": "^1.0.1"
+  },
   "peerDependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
@@ -26,5 +29,8 @@
     "prop-types": "^15.7.2",
     "react": "^18.2.0",
     "uuid": "^8.3.2"
+  },
+  "browser": {
+    "path": "path-browserify"
   }
 }

--- a/packages/decap-cms-core/package.json
+++ b/packages/decap-cms-core/package.json
@@ -43,6 +43,7 @@
     "js-base64": "^3.0.0",
     "jwt-decode": "^3.0.0",
     "node-polyglot": "^2.3.0",
+    "path-browserify": "^1.0.1",
     "prop-types": "^15.7.2",
     "react": "^18.2.0",
     "react-dnd": "^14.0.0",
@@ -96,5 +97,8 @@
     "@types/redux-mock-store": "^1.0.2",
     "@types/url-join": "^4.0.0",
     "redux-mock-store": "^1.5.3"
+  },
+  "browser": {
+    "path": "path-browserify"
   }
 }

--- a/packages/decap-cms-core/package.json
+++ b/packages/decap-cms-core/package.json
@@ -94,6 +94,7 @@
   },
   "devDependencies": {
     "@types/history": "^4.7.8",
+    "@types/iarna__toml": "^2.0.5",
     "@types/redux-mock-store": "^1.0.2",
     "@types/url-join": "^4.0.0",
     "redux-mock-store": "^1.5.3"

--- a/packages/decap-cms-core/src/formats/toml.ts
+++ b/packages/decap-cms-core/src/formats/toml.ts
@@ -1,4 +1,4 @@
-import toml from '@iarna/toml';
+import parseToml from '@iarna/toml/parse-string';
 import tomlify from 'tomlify-j0.4';
 import dayjs from 'dayjs';
 
@@ -24,7 +24,7 @@ function outputReplacer(_key: string, value: unknown) {
 
 export default {
   fromFile(content: string) {
-    return toml.parse(content);
+    return parseToml(content);
   },
 
   toFile(data: object, sortedKeys: string[] = []) {

--- a/packages/decap-cms-core/src/types/toml.d.ts
+++ b/packages/decap-cms-core/src/types/toml.d.ts
@@ -1,0 +1,4 @@
+declare module '@iarna/toml/parse-string' {
+  import type { JsonMap } from '@iarna/toml';
+  export default function (toml: string): JsonMap;
+}

--- a/packages/decap-cms-core/src/types/toml.d.ts
+++ b/packages/decap-cms-core/src/types/toml.d.ts
@@ -1,4 +1,0 @@
-declare module '@iarna/toml/parse-string' {
-  import type { JsonMap } from '@iarna/toml';
-  export default function (toml: string): JsonMap;
-}

--- a/packages/decap-cms-lib-widgets/package.json
+++ b/packages/decap-cms-lib-widgets/package.json
@@ -17,10 +17,14 @@
     "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore \"**/__tests__\" --root-mode upward --extensions \".js,.jsx,.ts,.tsx\""
   },
   "dependencies": {
-    "dayjs": "^1.11.10"
+    "dayjs": "^1.11.10",
+    "path-browserify": "^1.0.1"
   },
   "peerDependencies": {
     "immutable": "^3.7.6",
     "lodash": "^4.17.11"
+  },
+  "browser": {
+    "path": "path-browserify"
   }
 }

--- a/scripts/webpack.js
+++ b/scripts/webpack.js
@@ -140,11 +140,6 @@ function baseConfig({ target = isProduction ? 'umd' : 'umddir' } = {}) {
     },
     resolve: {
       extensions: ['.ts', '.tsx', '.js', '.json'],
-      fallback: {
-        path: require.resolve('path-browserify'),
-        stream: require.resolve('stream-browserify'),
-        buffer: require.resolve('buffer'),
-      },
     },
     plugins: Object.values(plugins()).map(plugin => plugin()),
     devtool: isTest ? '' : 'source-map',


### PR DESCRIPTION
**Summary**

This PR simplifies the setup for users consuming `decap-cms-app` directly by addressing Node.js built-in dependencies in a different way.

**Problem:**
1. Many decap packages depend on Node.js built-ins (particularly `path`)
2. Currently, these are only polyfilled via webpack configuration in the pre-built bundle
3. Users consuming `decap-cms-app` directly must manually configure their build tools to provide these polyfills

**Solution:**
1. Leverage the standard `browser` field in `package.json` to specify browser-compatible alternatives
   - This is widely supported by modern build tools (webpack, Vite, Rollup, etc.)
   - Eliminates need for manual polyfill configuration
2. Reduce polyfill requirements by:
   - Using `@iarna/toml/parse-string` instead of full `@iarna/toml` to eliminate `stream` dependency
   - Updating `minimatch` to a more recent version which removes Node.js built-in dependencies

These changes make the library more portable and easier to integrate across different build environments.

**Test plan**

* Build succeeds ✅ 
* tests:all pass ✅ 
* demo runs ✅ 
 
**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**

🐣