### PR TITLE
Add different i18n path structure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "decap-cms",
+  "name": "decap-cms-i18n-path-at-root",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "decap-cms-i18n-path-at-root",
+  "name": "decap-cms",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,

--- a/packages/decap-cms-core/src/lib/__tests__/i18n.spec.js
+++ b/packages/decap-cms-core/src/lib/__tests__/i18n.spec.js
@@ -41,10 +41,10 @@ describe('i18n', () => {
   });
 
   describe('getI18nFilesDepth', () => {
-    it('should increase depth when i18n structure is I18N_STRUCTURE.ROOT', () => {
+    it('should increase depth when i18n structure is I18N_STRUCTURE.MULTIPLE_FOLDERS_I18N_ROOT', () => {
       expect(
         i18n.getI18nFilesDepth(
-          fromJS({ i18n: { structure: i18n.I18N_STRUCTURE.ROOT } }),
+          fromJS({ i18n: { structure: i18n.I18N_STRUCTURE.MULTIPLE_FOLDERS_I18N_ROOT } }),
           5,
         ),
       ).toBe(6);
@@ -140,10 +140,10 @@ describe('i18n', () => {
   });
 
   describe('getFilePath', () => {
-    it('should return directory path based on locale when structure is I18N_STRUCTURE.ROOT', () => {
+    it('should return directory path based on locale when structure is I18N_STRUCTURE.MULTIPLE_FOLDERS_I18N_ROOT', () => {
       expect(
         i18n.getFilePath(
-          i18n.I18N_STRUCTURE.ROOT,
+          i18n.I18N_STRUCTURE.MULTIPLE_FOLDERS_I18N_ROOT,
           'md',
           'src/content/index.md',
           'index',
@@ -196,7 +196,10 @@ describe('i18n', () => {
       expect(
         i18n.getFilePaths(
           fromJS({
-            i18n: { structure: i18n.I18N_STRUCTURE.ROOT, locales: ['en', 'de'] },
+            i18n: {
+              structure: i18n.I18N_STRUCTURE.MULTIPLE_FOLDERS_I18N_ROOT,
+              locales: ['en', 'de'],
+            },
           }),
           ...args,
         ),
@@ -227,10 +230,10 @@ describe('i18n', () => {
   });
 
   describe('normalizeFilePath', () => {
-    it('should remove locale folder from path when structure is I18N_STRUCTURE.ROOT', () => {
+    it('should remove locale folder from path when structure is I18N_STRUCTURE.MULTIPLE_FOLDERS_I18N_ROOT', () => {
       expect(
         i18n.normalizeFilePath(
-          i18n.I18N_STRUCTURE.ROOT,
+          i18n.I18N_STRUCTURE.MULTIPLE_FOLDERS_I18N_ROOT,
           'src/en/content/index.md',
           'en',
         ),
@@ -261,10 +264,10 @@ describe('i18n', () => {
   });
 
   describe('getLocaleFromPath', () => {
-    it('should return the locale from folder name in the path when structure is I18N_STRUCTURE.ROOT', () => {
+    it('should return the locale from folder name in the path when structure is I18N_STRUCTURE.MULTIPLE_FOLDERS_I18N_ROOT', () => {
       expect(
         i18n.getLocaleFromPath(
-          i18n.I18N_STRUCTURE.ROOT,
+          i18n.I18N_STRUCTURE.MULTIPLE_FOLDERS_I18N_ROOT,
           'md',
           'src/en/content/index.md',
         ),
@@ -332,11 +335,15 @@ describe('i18n', () => {
       ]);
     });
 
-    it('should return a folder based files when structure is I18N_STRUCTURE.ROOT', () => {
+    it('should return a folder based files when structure is I18N_STRUCTURE.MULTIPLE_FOLDERS_I18N_ROOT', () => {
       expect(
         i18n.getI18nFiles(
           fromJS({
-            i18n: { structure: i18n.I18N_STRUCTURE.ROOT, locales, default_locale },
+            i18n: {
+              structure: i18n.I18N_STRUCTURE.MULTIPLE_FOLDERS_I18N_ROOT,
+              locales,
+              default_locale,
+            },
           }),
           ...args,
         ),
@@ -419,7 +426,7 @@ describe('i18n', () => {
     const default_locale = 'en';
     const args = ['md', 'src/content/index.md', 'index'];
 
-    it('should return i18n entry content when structure is I18N_STRUCTURE.ROOT', async () => {
+    it('should return i18n entry content when structure is I18N_STRUCTURE.MULTIPLE_FOLDERS_I18N_ROOT', async () => {
       const data = {
         'src/en/content/index.md': {
           slug: 'index',
@@ -444,7 +451,11 @@ describe('i18n', () => {
       await expect(
         i18n.getI18nEntry(
           fromJS({
-            i18n: { structure: i18n.I18N_STRUCTURE.ROOT, locales, default_locale },
+            i18n: {
+              structure: i18n.I18N_STRUCTURE.MULTIPLE_FOLDERS_I18N_ROOT,
+              locales,
+              default_locale,
+            },
           }),
           ...args,
           getEntryValue,
@@ -614,7 +625,7 @@ describe('i18n', () => {
     const default_locale = 'en';
     const extension = 'md';
 
-    it('should group entries array when structure is I18N_STRUCTURE.ROOT', () => {
+    it('should group entries array when structure is I18N_STRUCTURE.MULTIPLE_FOLDERS_I18N_ROOT', () => {
       const entries = [
         {
           slug: 'index',
@@ -636,7 +647,11 @@ describe('i18n', () => {
       expect(
         i18n.groupEntries(
           fromJS({
-            i18n: { structure: i18n.I18N_STRUCTURE.ROOT, locales, default_locale },
+            i18n: {
+              structure: i18n.I18N_STRUCTURE.MULTIPLE_FOLDERS_I18N_ROOT,
+              locales,
+              default_locale,
+            },
           }),
           extension,
           entries,
@@ -773,7 +788,11 @@ describe('i18n', () => {
       expect(
         i18n.getI18nDataFiles(
           fromJS({
-            i18n: { structure: i18n.I18N_STRUCTURE.ROOT, locales, default_locale },
+            i18n: {
+              structure: i18n.I18N_STRUCTURE.MULTIPLE_FOLDERS_I18N_ROOT,
+              locales,
+              default_locale,
+            },
           }),
           ...args,
           [{ path: 'src/fr/content/index.md', id: 'id', newFile: false }],
@@ -838,7 +857,11 @@ describe('i18n', () => {
       expect(
         i18n.getI18nBackup(
           fromJS({
-            i18n: { structure: i18n.I18N_STRUCTURE.ROOT, locales, default_locale },
+            i18n: {
+              structure: i18n.I18N_STRUCTURE.MULTIPLE_FOLDERS_I18N_ROOT,
+              locales,
+              default_locale,
+            },
           }),
           fromJS({
             data: 'raw_en',

--- a/packages/decap-cms-core/src/lib/__tests__/i18n.spec.js
+++ b/packages/decap-cms-core/src/lib/__tests__/i18n.spec.js
@@ -192,7 +192,7 @@ describe('i18n', () => {
   describe('getFilePaths', () => {
     const args = ['md', 'src/content/index.md', 'index'];
 
-    it('should return file paths for all locales with ROOT structure', () => {
+    it('should return file paths for all locales with MULTIPLE_FOLDERS_I18N_ROOT structure', () => {
       expect(
         i18n.getFilePaths(
           fromJS({
@@ -784,7 +784,7 @@ describe('i18n', () => {
 
     const args = ['md', 'src/content/index.md', 'index'];
 
-    it('should add missing locale files to diff files when structure is ROOT', () => {
+    it('should add missing locale files to diff files when structure is MULTIPLE_FOLDERS_I18N_ROOT', () => {
       expect(
         i18n.getI18nDataFiles(
           fromJS({
@@ -850,7 +850,7 @@ describe('i18n', () => {
   });
 
   describe('getI18nBackup', () => {
-    it('should return i18n with raw data with ROOT structure', () => {
+    it('should return i18n with raw data with MULTIPLE_FOLDERS_I18N_ROOT structure', () => {
       const locales = ['en', 'de', 'fr'];
       const default_locale = 'en';
 

--- a/packages/decap-cms-core/src/lib/__tests__/i18n.spec.js
+++ b/packages/decap-cms-core/src/lib/__tests__/i18n.spec.js
@@ -41,6 +41,15 @@ describe('i18n', () => {
   });
 
   describe('getI18nFilesDepth', () => {
+    it('should increase depth when i18n structure is I18N_STRUCTURE.ROOT', () => {
+      expect(
+        i18n.getI18nFilesDepth(
+          fromJS({ i18n: { structure: i18n.I18N_STRUCTURE.ROOT } }),
+          5,
+        ),
+      ).toBe(6);
+    });
+
     it('should increase depth when i18n structure is I18N_STRUCTURE.MULTIPLE_FOLDERS', () => {
       expect(
         i18n.getI18nFilesDepth(
@@ -131,6 +140,18 @@ describe('i18n', () => {
   });
 
   describe('getFilePath', () => {
+    it('should return directory path based on locale when structure is I18N_STRUCTURE.ROOT', () => {
+      expect(
+        i18n.getFilePath(
+          i18n.I18N_STRUCTURE.ROOT,
+          'md',
+          'src/content/index.md',
+          'index',
+          'de',
+        ),
+      ).toEqual('src/de/content/index.md');
+    });
+
     it('should return directory path based on locale when structure is I18N_STRUCTURE.MULTIPLE_FOLDERS', () => {
       expect(
         i18n.getFilePath(
@@ -171,7 +192,18 @@ describe('i18n', () => {
   describe('getFilePaths', () => {
     const args = ['md', 'src/content/index.md', 'index'];
 
-    it('should return file paths for all locales', () => {
+    it('should return file paths for all locales with ROOT structure', () => {
+      expect(
+        i18n.getFilePaths(
+          fromJS({
+            i18n: { structure: i18n.I18N_STRUCTURE.ROOT, locales: ['en', 'de'] },
+          }),
+          ...args,
+        ),
+      ).toEqual(['src/en/content/index.md', 'src/de/content/index.md']);
+    });
+
+    it('should return file paths for all locales with MULTIPLE_FOLDERS structure', () => {
       expect(
         i18n.getFilePaths(
           fromJS({
@@ -195,6 +227,16 @@ describe('i18n', () => {
   });
 
   describe('normalizeFilePath', () => {
+    it('should remove locale folder from path when structure is I18N_STRUCTURE.ROOT', () => {
+      expect(
+        i18n.normalizeFilePath(
+          i18n.I18N_STRUCTURE.ROOT,
+          'src/en/content/index.md',
+          'en',
+        ),
+      ).toEqual('src/content/index.md');
+    });
+
     it('should remove locale folder from path when structure is I18N_STRUCTURE.MULTIPLE_FOLDERS', () => {
       expect(
         i18n.normalizeFilePath(
@@ -219,6 +261,16 @@ describe('i18n', () => {
   });
 
   describe('getLocaleFromPath', () => {
+    it('should return the locale from folder name in the path when structure is I18N_STRUCTURE.ROOT', () => {
+      expect(
+        i18n.getLocaleFromPath(
+          i18n.I18N_STRUCTURE.ROOT,
+          'md',
+          'src/en/content/index.md',
+        ),
+      ).toEqual('en');
+    });
+
     it('should return the locale from folder name in the path when structure is I18N_STRUCTURE.MULTIPLE_FOLDERS', () => {
       expect(
         i18n.getLocaleFromPath(
@@ -275,6 +327,33 @@ describe('i18n', () => {
             de: { title: 'de_title' },
             fr: { title: 'fr_title' },
           },
+          slug: 'index',
+        },
+      ]);
+    });
+
+    it('should return a folder based files when structure is I18N_STRUCTURE.ROOT', () => {
+      expect(
+        i18n.getI18nFiles(
+          fromJS({
+            i18n: { structure: i18n.I18N_STRUCTURE.ROOT, locales, default_locale },
+          }),
+          ...args,
+        ),
+      ).toEqual([
+        {
+          path: 'src/en/content/index.md',
+          raw: { title: 'en_title' },
+          slug: 'index',
+        },
+        {
+          path: 'src/de/content/index.md',
+          raw: { title: 'de_title' },
+          slug: 'index',
+        },
+        {
+          path: 'src/fr/content/index.md',
+          raw: { title: 'fr_title' },
           slug: 'index',
         },
       ]);
@@ -339,6 +418,48 @@ describe('i18n', () => {
     const locales = ['en', 'de', 'fr', 'es'];
     const default_locale = 'en';
     const args = ['md', 'src/content/index.md', 'index'];
+
+    it('should return i18n entry content when structure is I18N_STRUCTURE.ROOT', async () => {
+      const data = {
+        'src/en/content/index.md': {
+          slug: 'index',
+          path: 'src/en/content/index.md',
+          data: { title: 'en_title' },
+        },
+        'src/de/content/index.md': {
+          slug: 'index',
+          path: 'src/de/content/index.md',
+          data: { title: 'de_title' },
+        },
+        'src/fr/content/index.md': {
+          slug: 'index',
+          path: 'src/fr/content/index.md',
+          data: { title: 'fr_title' },
+        },
+      };
+      const getEntryValue = jest.fn(path =>
+        data[path] ? Promise.resolve(data[path]) : Promise.reject('Not found'),
+      );
+
+      await expect(
+        i18n.getI18nEntry(
+          fromJS({
+            i18n: { structure: i18n.I18N_STRUCTURE.ROOT, locales, default_locale },
+          }),
+          ...args,
+          getEntryValue,
+        ),
+      ).resolves.toEqual({
+        slug: 'index',
+        path: 'src/content/index.md',
+        data: { title: 'en_title' },
+        i18n: {
+          de: { data: { title: 'de_title' } },
+          fr: { data: { title: 'fr_title' } },
+        },
+        raw: '',
+      });
+    });
 
     it('should return i18n entry content when structure is I18N_STRUCTURE.MULTIPLE_FOLDERS', async () => {
       const data = {
@@ -493,6 +614,44 @@ describe('i18n', () => {
     const default_locale = 'en';
     const extension = 'md';
 
+    it('should group entries array when structure is I18N_STRUCTURE.ROOT', () => {
+      const entries = [
+        {
+          slug: 'index',
+          path: 'src/en/content/index.md',
+          data: { title: 'en_title' },
+        },
+        {
+          slug: 'index',
+          path: 'src/de/content/index.md',
+          data: { title: 'de_title' },
+        },
+        {
+          slug: 'index',
+          path: 'src/fr/content/index.md',
+          data: { title: 'fr_title' },
+        },
+      ];
+
+      expect(
+        i18n.groupEntries(
+          fromJS({
+            i18n: { structure: i18n.I18N_STRUCTURE.ROOT, locales, default_locale },
+          }),
+          extension,
+          entries,
+        ),
+      ).toEqual([
+        {
+          slug: 'index',
+          path: 'src/content/index.md',
+          data: { title: 'en_title' },
+          i18n: { de: { data: { title: 'de_title' } }, fr: { data: { title: 'fr_title' } } },
+          raw: '',
+        },
+      ]);
+    });
+
     it('should group entries array when structure is I18N_STRUCTURE.MULTIPLE_FOLDERS', () => {
       const entries = [
         {
@@ -610,6 +769,22 @@ describe('i18n', () => {
 
     const args = ['md', 'src/content/index.md', 'index'];
 
+    it('should add missing locale files to diff files when structure is ROOT', () => {
+      expect(
+        i18n.getI18nDataFiles(
+          fromJS({
+            i18n: { structure: i18n.I18N_STRUCTURE.ROOT, locales, default_locale },
+          }),
+          ...args,
+          [{ path: 'src/fr/content/index.md', id: 'id', newFile: false }],
+        ),
+      ).toEqual([
+        { path: 'src/en/content/index.md', id: '', newFile: false },
+        { path: 'src/de/content/index.md', id: '', newFile: false },
+        { path: 'src/fr/content/index.md', id: 'id', newFile: false },
+      ]);
+    });
+
     it('should add missing locale files to diff files when structure is MULTIPLE_FOLDERS', () => {
       expect(
         i18n.getI18nDataFiles(
@@ -656,7 +831,28 @@ describe('i18n', () => {
   });
 
   describe('getI18nBackup', () => {
-    it('should return i18n with raw data', () => {
+    it('should return i18n with raw data with ROOT structure', () => {
+      const locales = ['en', 'de', 'fr'];
+      const default_locale = 'en';
+
+      expect(
+        i18n.getI18nBackup(
+          fromJS({
+            i18n: { structure: i18n.I18N_STRUCTURE.ROOT, locales, default_locale },
+          }),
+          fromJS({
+            data: 'raw_en',
+            i18n: {
+              de: { data: 'raw_de' },
+              fr: { data: 'raw_fr' },
+            },
+          }),
+          e => e.get('data'),
+        ),
+      ).toEqual({ de: { raw: 'raw_de' }, fr: { raw: 'raw_fr' } });
+    });
+
+    it('should return i18n with raw data with MULTIPLE FILES structure', () => {
       const locales = ['en', 'de', 'fr'];
       const default_locale = 'en';
 

--- a/packages/decap-cms-core/src/lib/i18n.ts
+++ b/packages/decap-cms-core/src/lib/i18n.ts
@@ -9,6 +9,7 @@ import type { EntryValue } from '../valueObjects/Entry';
 export const I18N = 'i18n';
 
 export enum I18N_STRUCTURE {
+  ROOT = 'root',
   MULTIPLE_FOLDERS = 'multiple_folders',
   MULTIPLE_FILES = 'multiple_files',
   SINGLE_FILE = 'single_file',
@@ -40,7 +41,7 @@ export function getI18nInfo(collection: Collection) {
 
 export function getI18nFilesDepth(collection: Collection, depth: number) {
   const { structure } = getI18nInfo(collection) as I18nInfo;
-  if (structure === I18N_STRUCTURE.MULTIPLE_FOLDERS) {
+  if (structure === I18N_STRUCTURE.MULTIPLE_FOLDERS || structure === I18N_STRUCTURE.ROOT) {
     return depth + 1;
   }
   return depth;
@@ -77,7 +78,11 @@ export function getFilePath(
   slug: string,
   locale: string,
 ) {
+  const parts = path.split('/');
   switch (structure) {
+    case I18N_STRUCTURE.ROOT:
+      parts.splice(1, 0, locale);
+      return parts.join("/")
     case I18N_STRUCTURE.MULTIPLE_FOLDERS:
       return path.replace(`/${slug}`, `/${locale}/${slug}`);
     case I18N_STRUCTURE.MULTIPLE_FILES:
@@ -90,6 +95,10 @@ export function getFilePath(
 
 export function getLocaleFromPath(structure: I18N_STRUCTURE, extension: string, path: string) {
   switch (structure) {
+    case I18N_STRUCTURE.ROOT: {
+      const parts = path.split('/');
+      return parts[1];
+    }
     case I18N_STRUCTURE.MULTIPLE_FOLDERS: {
       const parts = path.split('/');
       // filename
@@ -128,6 +137,7 @@ export function getFilePaths(
 
 export function normalizeFilePath(structure: I18N_STRUCTURE, path: string, locale: string) {
   switch (structure) {
+    case I18N_STRUCTURE.ROOT:
     case I18N_STRUCTURE.MULTIPLE_FOLDERS:
       return path.replace(`${locale}/`, '');
     case I18N_STRUCTURE.MULTIPLE_FILES:

--- a/packages/decap-cms-core/src/lib/i18n.ts
+++ b/packages/decap-cms-core/src/lib/i18n.ts
@@ -9,7 +9,7 @@ import type { EntryValue } from '../valueObjects/Entry';
 export const I18N = 'i18n';
 
 export enum I18N_STRUCTURE {
-  ROOT = 'root',
+  MULTIPLE_FOLDERS_I18N_ROOT = 'multiple_folders_i18n_root',
   MULTIPLE_FOLDERS = 'multiple_folders',
   MULTIPLE_FILES = 'multiple_files',
   SINGLE_FILE = 'single_file',
@@ -41,7 +41,10 @@ export function getI18nInfo(collection: Collection) {
 
 export function getI18nFilesDepth(collection: Collection, depth: number) {
   const { structure } = getI18nInfo(collection) as I18nInfo;
-  if (structure === I18N_STRUCTURE.MULTIPLE_FOLDERS || structure === I18N_STRUCTURE.ROOT) {
+  if (
+    structure === I18N_STRUCTURE.MULTIPLE_FOLDERS ||
+    structure === I18N_STRUCTURE.MULTIPLE_FOLDERS_I18N_ROOT
+  ) {
     return depth + 1;
   }
   return depth;
@@ -80,9 +83,9 @@ export function getFilePath(
 ) {
   const parts = path.split('/');
   switch (structure) {
-    case I18N_STRUCTURE.ROOT:
+    case I18N_STRUCTURE.MULTIPLE_FOLDERS_I18N_ROOT:
       parts.splice(1, 0, locale);
-      return parts.join("/")
+      return parts.join('/');
     case I18N_STRUCTURE.MULTIPLE_FOLDERS:
       return path.replace(`/${slug}`, `/${locale}/${slug}`);
     case I18N_STRUCTURE.MULTIPLE_FILES:
@@ -95,7 +98,7 @@ export function getFilePath(
 
 export function getLocaleFromPath(structure: I18N_STRUCTURE, extension: string, path: string) {
   switch (structure) {
-    case I18N_STRUCTURE.ROOT: {
+    case I18N_STRUCTURE.MULTIPLE_FOLDERS_I18N_ROOT: {
       const parts = path.split('/');
       return parts[1];
     }
@@ -137,7 +140,7 @@ export function getFilePaths(
 
 export function normalizeFilePath(structure: I18N_STRUCTURE, path: string, locale: string) {
   switch (structure) {
-    case I18N_STRUCTURE.ROOT:
+    case I18N_STRUCTURE.MULTIPLE_FOLDERS_I18N_ROOT:
     case I18N_STRUCTURE.MULTIPLE_FOLDERS:
       return path.replace(`${locale}/`, '');
     case I18N_STRUCTURE.MULTIPLE_FILES:


### PR DESCRIPTION
**Summary**

We have an overall i18n path strategy to place the locale just after the root, and decap does not support this out of the box. To fix this, we added a new structure to i18n.ts.

**Test plan**

npm run test && npm run format are passing
![image](https://github.com/user-attachments/assets/51462156-78b2-4ac0-87bd-b16d6e8dfd0d)

![image](https://github.com/user-attachments/assets/dfe6badd-3b00-4ccc-a323-c0f3107c8f25)
...
![image](https://github.com/user-attachments/assets/2f8c83f1-c8a2-453f-9f89-137c7240ff59)



**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).
- [x] tests updated, performed and passed
- [x] code linted successfully
- [x] feature branch rebased before PR

**A picture of a cute animal (not mandatory but encouraged)**
If you don't approve this PR, Piper will be sad.
![image](https://github.com/user-attachments/assets/c0c26afb-b7fa-4450-b53a-431792fe461f)
Do it for Piper :)
