### PR TITLE
fix(#7401): move stega.ts to core package

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,7 @@ module.exports = {
     'decap-cms-widget-object': '<rootDir>/packages/decap-cms-widget-object/src/index.js',
     '\\.(css|less)$': '<rootDir>/__mocks__/styleMock.js',
   },
+  modulePathIgnorePatterns: ['.nx', 'dist'],
   snapshotSerializers: ['@emotion/jest/serializer'],
   transformIgnorePatterns: [
     'node_modules/(?!copy-text-to-clipboard|clean-stack|escape-string-regexp)',

--- a/packages/decap-cms-core/index.d.ts
+++ b/packages/decap-cms-core/index.d.ts
@@ -306,6 +306,7 @@ declare module 'decap-cms-core' {
     hide?: boolean;
     editor?: {
       preview?: boolean;
+      visualEditing?: boolean;
     };
     publish?: boolean;
     nested?: {

--- a/packages/decap-cms-core/src/components/Editor/EditorPreviewPane/EditorPreviewPane.js
+++ b/packages/decap-cms-core/src/components/Editor/EditorPreviewPane/EditorPreviewPane.js
@@ -6,8 +6,8 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import Frame, { FrameContextConsumer } from 'react-frame-component';
 import { lengths } from 'decap-cms-ui-default';
 import { connect } from 'react-redux';
-import { encodeEntry } from 'decap-cms-lib-util/src/stega';
 
+import { encodeEntry } from '../../../lib/stega';
 import {
   resolveWidget,
   getPreviewTemplate,

--- a/packages/decap-cms-core/src/lib/stega.ts
+++ b/packages/decap-cms-core/src/lib/stega.ts
@@ -1,6 +1,5 @@
 import { vercelStegaEncode } from '@vercel/stega';
-
-import { isImmutableMap, isImmutableList } from './types';
+import { isImmutableMap, isImmutableList } from 'decap-cms-lib-util/src/types';
 
 import type { Map as ImmutableMap, List } from 'immutable';
 import type { CmsField } from 'decap-cms-core';

--- a/packages/decap-cms-core/src/types/redux.ts
+++ b/packages/decap-cms-core/src/types/redux.ts
@@ -322,6 +322,7 @@ export interface CmsCollection {
   delete?: boolean;
   editor?: {
     preview?: boolean;
+    visualEditing?: boolean;
   };
   publish?: boolean;
   nested?: {


### PR DESCRIPTION
**Summary**

This PR fixes #7401 by moving stega.ts to the core package, thereby getting rid of the circular dependency.

Additional changes:

- Adds the new `visualEditing` prop to the type declarations
- Allows running tests _after_ a build by ignoring `.nx` and `dist` in jest

**Test plan**

Use decap-cms-app in an external project.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**

🦦
