### PR TITLE
Fix: nested + i18n customPath issue

### DIFF
--- a/packages/decap-cms-core/src/backend.ts
+++ b/packages/decap-cms-core/src/backend.ts
@@ -1128,12 +1128,13 @@ export class Backend {
       updateAssetProxies(assetProxies, config, collection, entryDraft, path);
     } else {
       const slug = entryDraft.getIn(['entry', 'slug']);
+      const path = entryDraft.getIn(['entry', 'path']);
       dataFile = {
-        path: entryDraft.getIn(['entry', 'path']),
+        path,
         // for workflow entries we refresh the slug on publish
         slug: customPath && !useWorkflow ? slugFromCustomPath(collection, customPath) : slug,
         raw: this.entryToRaw(collection, entryDraft.get('entry')),
-        newPath: customPath,
+        newPath: customPath === path ? undefined : customPath,
       };
     }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

Addressing https://github.com/decaporg/decap-cms/issues/7389

When using nested collection combined with i18n, we encountered a bug, where instead of saving content, we would get empty commits. This did not happen when using local backend via proxy. 
After inspecting exactly what happens in the backend implementation I figured out that the problem actually happens in `backend.ts` when it sets the `newPath` property as if the file was being renamed every time the customPath is set. This way the updateTree function in the API.ts goes into another mode, loops the i18n files and eventually updates the tree with existing blob IDS instead of the newly uploaded ones. 
Added a condition where newPath is passed on only if it differs from the currentPath - so only in case the file is actually being moved.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**

```
local_backend: true

backend:
  name: git-gateway
  branch: decap-debug
  squash_merges: true

display_url: https://hugo-template.netlify.app/
logo_url: /media/brand/logo.svg
media_folder: static/media/uploads
public_folder: /media/uploads

i18n:
  structure: multiple_files
  locales: [en, sl]

slug:
  encoding: ascii
  clean_accents: true

collections:
  - label: 'subfolders'
    name: 'subfolders'
    folder: 'content/subfolders'
    identifier_field: 'title'
    create: true
    i18n: true
    extension: 'md'
    meta: { path: { widget: string, label: 'Path', index_file: 'index' } }
    nested:
      depth: 10
      subfolders: true
      summary: '{{title}}'
    fields:
      - { label: 'Title', name: 'title', widget: 'string', i18n: true }

```

Directory structure
```
subfolders
└── management
    ├── index.en.md
    ├── index.sl.md
    └── nested
        └── index.en.md
```

When editing the nested entry using Github gateway it will no longer result in an empty commit instead of crating the index.sl.md file.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**Checklist**

Please add a `x` inside each checkbox:

- [ ] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
![image](https://github.com/user-attachments/assets/71413087-b79f-4261-a5e5-7abc9f21d8e8)

