### PR TITLE
fix(7281): remove the string "DRAFT_MEDIA_FILES"

### DIFF
--- a/packages/decap-cms-core/src/reducers/__tests__/entries.spec.js
+++ b/packages/decap-cms-core/src/reducers/__tests__/entries.spec.js
@@ -85,7 +85,7 @@ describe('entries', () => {
       ).toEqual('static/media');
     });
 
-    it('should return draft media folder when collection specifies media_folder and entry is undefined', () => {
+    it('should return collection folder when collection specifies media_folder and entry is undefined', () => {
       expect(
         selectMediaFolder(
           { media_folder: 'static/media' },
@@ -93,7 +93,7 @@ describe('entries', () => {
           undefined,
           undefined,
         ),
-      ).toEqual('posts/DRAFT_MEDIA_FILES');
+      ).toEqual('posts');
     });
 
     it('should return relative media folder when collection specifies media_folder and entry path is not null', () => {
@@ -364,7 +364,7 @@ describe('entries', () => {
           'image.png',
           undefined,
         ),
-      ).toBe('posts/DRAFT_MEDIA_FILES/image.png');
+      ).toBe('posts/image.png');
     });
 
     it('should handle relative media_folder', () => {

--- a/packages/decap-cms-core/src/reducers/entries.ts
+++ b/packages/decap-cms-core/src/reducers/entries.ts
@@ -527,8 +527,6 @@ export function selectIsFetching(state: Entries, collection: string) {
   return state.getIn(['pages', collection, 'isFetching'], false);
 }
 
-const DRAFT_MEDIA_FILES = 'DRAFT_MEDIA_FILES';
-
 function getFileField(collectionFiles: CollectionFiles, slug: string | undefined) {
   const file = collectionFiles.find(f => f?.get('name') === slug);
   return file;
@@ -747,7 +745,7 @@ export function selectMediaFolder(
       const entryPath = entryMap?.get('path');
       mediaFolder = entryPath
         ? join(dirname(entryPath), folder)
-        : join(collection!.get('folder') as string, DRAFT_MEDIA_FILES);
+        : (collection!.get('folder') as string);
     }
   }
 


### PR DESCRIPTION

The first two fields are mandatory:
-->

**Summary**

This fixes #7281.

I simply removed the string ```DRAFT_MEDIA_FILES``` from the return value of ```selectMediaFolder``` and the issue disappeared.
I have no idea why this string existed in the first place, but i highly advise that someone with more insight takes a look at this PR in case it breaks anything.

**Test plan**

I updated the corresponding test to reflect how i think this should work.
```npm run test``` doesn't show any failures.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).
