### PR TITLE
fix(markdown): extra whitespace before and after pasted content #7364

### DIFF
--- a/packages/decap-cms-widget-markdown/src/MarkdownControl/plugins/html/withHtml.js
+++ b/packages/decap-cms-widget-markdown/src/MarkdownControl/plugins/html/withHtml.js
@@ -37,7 +37,7 @@ const INLINE_STYLES = {
 
 function deserialize(el) {
   if (el.nodeType === 3) {
-    return el.textContent;
+    return el.textContent.trim();
   } else if (el.nodeType !== 1) {
     return null;
   } else if (el.nodeName === 'BR') {

--- a/packages/decap-cms-widget-markdown/src/MarkdownControl/plugins/html/withHtml.js
+++ b/packages/decap-cms-widget-markdown/src/MarkdownControl/plugins/html/withHtml.js
@@ -37,7 +37,7 @@ const INLINE_STYLES = {
 
 function deserialize(el) {
   if (el.nodeType === 3) {
-    return el.textContent.trim();
+    return el.textContent.replace(/(\r)?\n/g, '');
   } else if (el.nodeType !== 1) {
     return null;
   } else if (el.nodeName === 'BR') {


### PR DESCRIPTION
**Summary**

Fixes #7364 

parsing html allows also having text outside proper html tags. Which means that parsing pasted html `<body>\n<span>`  keeps `\n` character, because it's evaluated as text between tags.
Solved by replacing newline characters in this case

**Test plan**

No new lines after pasting content

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/user-attachments/assets/851527f4-b157-4ac9-a221-c00432c64be7)
