### PR TITLE
fix: relation widget duplicated requests

### DIFF
--- a/packages/decap-cms-widget-relation/src/RelationControl.js
+++ b/packages/decap-cms-widget-relation/src/RelationControl.js
@@ -188,6 +188,7 @@ export default class RelationControl extends React.Component {
 
   state = {
     initialOptions: [],
+    queryOptions: [],
   };
 
   static propTypes = {
@@ -236,10 +237,14 @@ export default class RelationControl extends React.Component {
     // if the field has a previous value perform an initial search based on the value field
     // this is required since each search is limited by optionsLength so the selected value
     // might not show up on the search
-    const { forID, field, value, query, onChange } = this.props;
+    const { forID, field, value, query, onChange, queryHits } = this.props;
     const collection = field.get('collection');
     const file = field.get('file');
     const initialSearchValues = value && (this.isMultiple() ? getSelectedOptions(value) : [value]);
+
+    const queryOptions = this.parseHitOptions(queryHits);
+    this.setState({ queryOptions });
+
     if (initialSearchValues && initialSearchValues.length > 0) {
       const metadata = {};
       const searchFieldsArray = getFieldArray(field.get('search_fields'));
@@ -401,13 +406,11 @@ export default class RelationControl extends React.Component {
   }, 500);
 
   render() {
-    const { value, field, forID, classNameWrapper, setActiveStyle, setInactiveStyle, queryHits } =
-      this.props;
+    const { value, field, forID, classNameWrapper, setActiveStyle, setInactiveStyle } = this.props;
     const isMultiple = this.isMultiple();
     const isClearable = !field.get('required', true) || isMultiple;
 
-    const queryOptions = this.parseHitOptions(queryHits);
-    const options = uniqOptions(this.state.initialOptions, queryOptions);
+    const options = uniqOptions(this.state.initialOptions, this.state.queryOptions);
     const selectedValue = getSelectedValue({
       options,
       value,


### PR DESCRIPTION
**Summary**

Relation widget is making duplicated requests for each call of component's `render` function

**Test plan**

network tab is a lot less populated. And relation widgets works (tested also with more than 20 relations)

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
![wildlife_image_2024_gold_winner](https://github.com/user-attachments/assets/a03db3c3-90eb-42cf-ae62-096b7750b2e3)
