### PR TITLE
fix: dropdown menu with adjusts to content

### DIFF
--- a/packages/decap-cms-core/src/components/Editor/EditorToolbar.js
+++ b/packages/decap-cms-core/src/components/Editor/EditorToolbar.js
@@ -450,7 +450,7 @@ export class EditorToolbar extends React.Component {
     return canPublish || canCreate ? (
       <ToolbarDropdown
         dropdownTopOverlap="40px"
-        dropdownWidth="150px"
+        dropdownWidth="max-content"
         key="td-publish-create"
         renderButton={() => (
           <PublishedToolbarButton>
@@ -486,7 +486,7 @@ export class EditorToolbar extends React.Component {
     return canCreate ? (
       <ToolbarDropdown
         dropdownTopOverlap="40px"
-        dropdownWidth="150px"
+        dropdownWidth="max-content"
         renderButton={() => (
           <PublishedToolbarButton>{t('editor.editorToolbar.published')}</PublishedToolbarButton>
         )}
@@ -511,7 +511,7 @@ export class EditorToolbar extends React.Component {
       <div>
         <ToolbarDropdown
           dropdownTopOverlap="40px"
-          dropdownWidth="150px"
+          dropdownWidth="max-content"
           renderButton={() => (
             <PublishButton>
               {isPersisting


### PR DESCRIPTION
This will fix #7479 

Test: open the UI with a german environment and add a new entry. The old version will have the entries in the dropdown menu for publishing cropped. This change fixes this.

![image](https://github.com/user-attachments/assets/06638358-8b8b-408e-b79b-5397931ab619)
