### PR TITLE
chore : Fix allowed users check by trimming spaces, ignoring case and improve cache restore message for clarity

### DIFF
--- a/functions/publish.js
+++ b/functions/publish.js
@@ -53,13 +53,15 @@ exports.handler = async function(event) {
     const command = params.get('command');
     const userId = params.get('user_id');
 
-    const allowedUsers = (process.env.ALLOWED_USERS || '').split(',');
-    if (!allowedUsers.includes(userId)) {
+    const allowedUsers = (process.env.ALLOWED_USERS || '')
+      .split(',')
+      .map(u => u.trim().toLowerCase());
+    if (!allowedUsers.includes(userId.toLowerCase())) {
       throw new Error(`User '${params.get('user_name')}' is not allowed to run command`);
     }
 
     const expectedCommand = process.env.PUBLISH_COMMAND;
-    if (expectedCommand && expectedCommand == command) {
+    if (expectedCommand && expectedCommand === command) {
       const githubToken = process.env.GITHUB_TOKEN;
       const repo = process.env.GITHUB_REPO;
       await axios({

--- a/scripts/cache.js
+++ b/scripts/cache.js
@@ -8,7 +8,7 @@ cache({
     {
       path: path.join(os.homedir(), '.cache', 'Cypress'),
       invalidateOn: __filename,
-      command: 'echo noop',
+      command: 'echo "No operation needed — cache intact"',
     },
   ],
   ignoreIfFolderExists: false,


### PR DESCRIPTION
**Summary**

This change ensures that when ALLOWED_USERS is split, each user ID is trimmed of whitespace and compared in a case-insensitive manner.
Previously, extra spaces or mismatched casing in the environment variable could prevent valid users from being recognized.
Improved the cache restore log message in the build configuration.
Replaced echo noop with a more descriptive message:
echo "No operation needed — cache intact".
This makes CI/CD logs clearer, helping developers quickly understand that the cache step was executed successfully but no rebuild was needed.

**Test plan**

Set ALLOWED_USERS=" U12345 ,u67890 " in .env.
Trigger a request with user_id="U12345" and user_id="u67890" — both should match successfully.
Trigger a request with an unauthorized user_id and confirm it is blocked.
Verify no change in functionality for already matching, correctly formatted user IDs.
Ran the build process with the updated message.
Verified that the new log text appears in the build output without affecting cache functionality.
Confirmed no side effects on cache restore behavior.

**Checklist**

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

:)

<img width="428" height="292" alt="image" src="https://github.com/user-attachments/assets/a3117eab-9ce1-480c-b9d3-d5533771a489" />

