### PR TITLE
Fixed image editor component pattern

### DIFF
--- a/packages/decap-cms-editor-component-image/src/index.js
+++ b/packages/decap-cms-editor-component-image/src/index.js
@@ -17,7 +17,7 @@ const image = {
     const src = getAsset(image, imageField);
     return <img src={src || ''} alt={alt || ''} title={title || ''} />;
   },
-  pattern: /^!\[(.*)\]\((.*?)(\s"(.*)")?\)$/,
+  pattern: /^!\[(.*)\]\((.*?)(\s"(.*)")?\)/,
   fields: [
     {
       label: 'Image',


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

This PR updates the `pattern` prop of the Image editor component and fixes the issue #7575.

The problem was that the previous regex pattern expected the image Markdown to occupy the entire string, using ^ at the start and $ at the end. As a result, images embedded in Markdown blocks with preceding or trailing text, blank lines, or paragraphs were not detected, breaking the editor preview for these images.

The proposed solution removes the $ anchor at the end and uses a global regex that matches images anywhere in the Markdown block. This ensures that images like:

```md
Lorem ipsum text

![Alternative text](/media/foo.png)

More text
```

are correctly recognized by the Image editor component and rendered in both the rich text editor and preview pane.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

- Verified that Markdown containing images between paragraphs renders correctly in the editor.
- Confirmed that newly uploaded images (blobs) appear immediately in the preview.
- Existing images continue to render correctly without changes to Markdown.

Here is an example of the Docusaurus demo content with an image between paragraphs:

<img width="1267" height="842" alt="decap-fix-7575" src="https://github.com/user-attachments/assets/44196ff3-a3ed-4139-bcd7-2ff2bfeece6e" />

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).