### PR TITLE
Prevent select dropdown item text wrapping

### DIFF
--- a/packages/decap-cms-ui-default/src/styles.js
+++ b/packages/decap-cms-ui-default/src/styles.js
@@ -376,6 +376,9 @@ const reactSelectStyles = {
     border: 0,
     boxShadow: 'none',
     padding: '9px 0 9px 12px',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
   }),
   option: (styles, state) => ({
     ...styles,


### PR DESCRIPTION
**Summary**

<img width="521" height="400" alt="image" src="https://github.com/user-attachments/assets/ce2dd7c6-0957-422b-8e2b-3820fbac071d" />

Currently long items in select controls (e.g. in a relation widget) will wrap and overlap subsequent items, since all items are positioned absolutely with a fixed height, and overflow is not hidden. The issue appears to be agnostic of browser; I have reproduced the issue in Firefox, Chrome, and Safari.

**Test plan**

I've tested my change in the three browsers I mentioned above. At least for modern versions of these browsers, the changes work as expected.

<img width="523" height="400" alt="image" src="https://github.com/user-attachments/assets/9793397e-5fff-48cf-b0e2-c38b58614868" />

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

Here's are my boys Moss and Roy sharing a chair that's too small for them

![image](https://github.com/user-attachments/assets/0743b7ff-7cc6-4b7b-b0d1-acb088306377)


