### PR TITLE
Sanitize HTML links and images, enhance proxy URL validation

### DIFF
--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -55,7 +55,7 @@ collections: # A list of collections the CMS should be able to edit
         required: false
         tagname: ''
 
-      - { label: 'Body', name: 'body', widget: 'richtext', hint: 'Main content goes here.', sanitize_preview: false }
+      - { label: 'Body', name: 'body', widget: 'richtext', hint: 'Main content goes here.' }
       - { label: 'Body', name: 'bodyold', widget: 'markdown', hint: 'Main content goes here.' }
       - { label: 'Body', name: 'bodyold2', widget: 'markdown', hint: 'Main content goes here 2.' }
 

--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -55,7 +55,7 @@ collections: # A list of collections the CMS should be able to edit
         required: false
         tagname: ''
 
-      - { label: 'Body', name: 'body', widget: 'richtext', hint: 'Main content goes here.' }
+      - { label: 'Body', name: 'body', widget: 'richtext', hint: 'Main content goes here.', sanitize_preview: false }
       - { label: 'Body', name: 'bodyold', widget: 'markdown', hint: 'Main content goes here.' }
       - { label: 'Body', name: 'bodyold2', widget: 'markdown', hint: 'Main content goes here 2.' }
 

--- a/packages/decap-cms-backend-proxy/src/__tests__/implementation.spec.ts
+++ b/packages/decap-cms-backend-proxy/src/__tests__/implementation.spec.ts
@@ -1,0 +1,37 @@
+import ProxyBackend from '../implementation';
+
+describe('ProxyBackend', () => {
+  function createConfig(proxyUrl?: string): ConstructorParameters<typeof ProxyBackend>[0] {
+    return {
+      backend: {
+        name: 'proxy',
+        proxy_url: proxyUrl,
+      },
+      media_folder: 'static/uploads',
+    } as ConstructorParameters<typeof ProxyBackend>[0];
+  }
+
+  it('should throw if proxy_url is missing', () => {
+    expect(() => new ProxyBackend(createConfig(undefined))).toThrow(
+      'The Proxy backend needs a "proxy_url" in the backend configuration.',
+    );
+  });
+
+  it('should allow root-relative proxy URLs', () => {
+    expect(() => new ProxyBackend(createConfig('/api/v1'))).not.toThrow();
+  });
+
+  it('should allow http and https proxy URLs', () => {
+    expect(() => new ProxyBackend(createConfig('http://localhost:8081/api/v1'))).not.toThrow();
+    expect(() => new ProxyBackend(createConfig('https://proxy.example.com/api/v1'))).not.toThrow();
+  });
+
+  it('should reject unsafe proxy URL schemes', () => {
+    expect(() => new ProxyBackend(createConfig('javascript:alert(1)'))).toThrow(
+      'The Proxy backend requires an http(s) or root-relative "proxy_url".',
+    );
+    expect(() => new ProxyBackend(createConfig('file:///etc/passwd'))).toThrow(
+      'The Proxy backend requires an http(s) or root-relative "proxy_url".',
+    );
+  });
+});

--- a/packages/decap-cms-backend-proxy/src/__tests__/implementation.spec.ts
+++ b/packages/decap-cms-backend-proxy/src/__tests__/implementation.spec.ts
@@ -21,6 +21,12 @@ describe('ProxyBackend', () => {
     expect(() => new ProxyBackend(createConfig('/api/v1'))).not.toThrow();
   });
 
+  it('should reject protocol-relative proxy URLs', () => {
+    expect(() => new ProxyBackend(createConfig('//evil.com/api'))).toThrow(
+      'The Proxy backend requires an http(s) or root-relative "proxy_url".',
+    );
+  });
+
   it('should allow http and https proxy URLs', () => {
     expect(() => new ProxyBackend(createConfig('http://localhost:8081/api/v1'))).not.toThrow();
     expect(() => new ProxyBackend(createConfig('https://proxy.example.com/api/v1'))).not.toThrow();
@@ -32,6 +38,13 @@ describe('ProxyBackend', () => {
     );
     expect(() => new ProxyBackend(createConfig('file:///etc/passwd'))).toThrow(
       'The Proxy backend requires an http(s) or root-relative "proxy_url".',
+    );
+  });
+
+  it('should trim surrounding whitespace for valid proxy URLs', () => {
+    expect(new ProxyBackend(createConfig('  /api/v1  ')).proxyUrl).toBe('/api/v1');
+    expect(new ProxyBackend(createConfig('  https://proxy.example.com/api/v1  ')).proxyUrl).toBe(
+      'https://proxy.example.com/api/v1',
     );
   });
 });

--- a/packages/decap-cms-backend-proxy/src/implementation.ts
+++ b/packages/decap-cms-backend-proxy/src/implementation.ts
@@ -31,6 +31,19 @@ type MediaFile = {
   path: string;
 };
 
+function isValidProxyUrl(proxyUrl: string) {
+  if (proxyUrl.startsWith('/')) {
+    return true;
+  }
+
+  try {
+    const parsed = new URL(proxyUrl);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
 function deserializeMediaFile({ id, content, encoding, path, name }: MediaFile) {
   let byteArray = new Uint8Array(0);
   if (encoding !== 'base64') {
@@ -58,6 +71,10 @@ export default class ProxyBackend implements Implementation {
   constructor(config: Config, options = {}) {
     if (!config.backend.proxy_url) {
       throw new Error('The Proxy backend needs a "proxy_url" in the backend configuration.');
+    }
+
+    if (!isValidProxyUrl(config.backend.proxy_url)) {
+      throw new Error('The Proxy backend requires an http(s) or root-relative "proxy_url".');
     }
 
     this.branch = config.backend.branch || 'master';

--- a/packages/decap-cms-backend-proxy/src/implementation.ts
+++ b/packages/decap-cms-backend-proxy/src/implementation.ts
@@ -31,16 +31,26 @@ type MediaFile = {
   path: string;
 };
 
-function isValidProxyUrl(proxyUrl: string) {
-  if (proxyUrl.startsWith('/')) {
-    return true;
+function normalizeProxyUrl(proxyUrl: string) {
+  const normalizedProxyUrl = proxyUrl.trim();
+
+  if (!normalizedProxyUrl) {
+    return null;
+  }
+
+  if (normalizedProxyUrl.startsWith('/') && !normalizedProxyUrl.startsWith('//')) {
+    return normalizedProxyUrl;
   }
 
   try {
-    const parsed = new URL(proxyUrl);
-    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    const parsed = new URL(normalizedProxyUrl);
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return normalizedProxyUrl;
+    }
+
+    return null;
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -73,12 +83,14 @@ export default class ProxyBackend implements Implementation {
       throw new Error('The Proxy backend needs a "proxy_url" in the backend configuration.');
     }
 
-    if (!isValidProxyUrl(config.backend.proxy_url)) {
+    const normalizedProxyUrl = normalizeProxyUrl(config.backend.proxy_url);
+
+    if (!normalizedProxyUrl) {
       throw new Error('The Proxy backend requires an http(s) or root-relative "proxy_url".');
     }
 
     this.branch = config.backend.branch || 'master';
-    this.proxyUrl = config.backend.proxy_url;
+    this.proxyUrl = normalizedProxyUrl;
     this.mediaFolder = config.media_folder;
     this.options = options;
     this.cmsLabelPrefix = config.backend.cms_label_prefix;

--- a/packages/decap-cms-core/src/actions/__tests__/config.spec.js
+++ b/packages/decap-cms-core/src/actions/__tests__/config.spec.js
@@ -862,6 +862,20 @@ describe('config', () => {
 
       assetFetchCalled('http://192.168.0.1:8081/api/v1');
     });
+
+    it('should return empty object when local_backend url has an unsafe scheme', async () => {
+      window.location = { hostname: 'localhost' };
+      global.fetch = jest.fn();
+      await expect(detectProxyServer({ url: 'file:///etc/passwd' })).resolves.toEqual({});
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should return empty object when local_backend url is not a valid URL', async () => {
+      window.location = { hostname: 'localhost' };
+      global.fetch = jest.fn();
+      await expect(detectProxyServer({ url: 'not a url' })).resolves.toEqual({});
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
   });
 
   describe('handleLocalBackend', () => {

--- a/packages/decap-cms-core/src/actions/config.ts
+++ b/packages/decap-cms-core/src/actions/config.ts
@@ -459,6 +459,17 @@ export async function detectProxyServer(localBackend?: boolean | CmsLocalBackend
       : localBackend.url || defaultUrl.replace('localhost', location.hostname);
 
   try {
+    const { protocol } = new URL(proxyUrl);
+    if (protocol !== 'http:' && protocol !== 'https:') {
+      console.log(`Decap CMS local_backend url must use http or https, ignoring '${proxyUrl}'`);
+      return {};
+    }
+  } catch {
+    console.log(`Decap CMS local_backend url '${proxyUrl}' is not a valid URL`);
+    return {};
+  }
+
+  try {
     console.log(`Looking for Decap CMS Proxy Server at '${proxyUrl}'`);
     const res = await fetch(`${proxyUrl}`, {
       method: 'POST',

--- a/packages/decap-cms-lib-auth/src/__tests__/pkce-oauth.spec.js
+++ b/packages/decap-cms-lib-auth/src/__tests__/pkce-oauth.spec.js
@@ -1,0 +1,84 @@
+import PkceAuthenticator from '../pkce-oauth';
+
+const CODE_VERIFIER_STORAGE_KEY = 'decap-cms-pkce-verifier-code';
+const AUTH_NONCE_STORAGE_KEY = 'decap-cms-auth';
+
+function setAuthCallbackUrl(query) {
+  window.history.replaceState(null, '', `/${query}`);
+}
+
+function setValidNonce(nonce = 'nonce-123') {
+  window.sessionStorage.setItem(AUTH_NONCE_STORAGE_KEY, JSON.stringify({ nonce }));
+  return nonce;
+}
+
+describe('PkceAuthenticator', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+    setAuthCallbackUrl('');
+  });
+
+  it('should clear code verifier when provider returns an auth error', async () => {
+    const nonce = setValidNonce();
+    const state = encodeURIComponent(JSON.stringify({ nonce }));
+    setAuthCallbackUrl(`?error=access_denied&error_description=Denied&state=${state}`);
+    window.sessionStorage.setItem(CODE_VERIFIER_STORAGE_KEY, 'verifier');
+
+    const authenticator = new PkceAuthenticator({
+      use_oidc: false,
+      base_url: 'https://example.com',
+      auth_endpoint: 'authorize',
+      auth_token_endpoint: 'oauth/token',
+      auth_token_endpoint_content_type: 'application/json',
+      app_id: 'app-id',
+    });
+    const cb = jest.fn();
+
+    await authenticator.completeAuth(cb);
+
+    expect(cb).toHaveBeenCalledWith(new Error('access_denied: Denied'));
+    expect(window.sessionStorage.getItem(CODE_VERIFIER_STORAGE_KEY)).toBeNull();
+  });
+
+  it('should clear code verifier when OIDC config loading fails', async () => {
+    const nonce = setValidNonce();
+    const state = encodeURIComponent(JSON.stringify({ nonce }));
+    setAuthCallbackUrl(`?code=auth-code&state=${state}`);
+    window.sessionStorage.setItem(CODE_VERIFIER_STORAGE_KEY, 'verifier');
+
+    const authenticator = new PkceAuthenticator({
+      use_oidc: true,
+      base_url: 'https://example.com',
+    });
+    jest.spyOn(authenticator, '_loadOidcConfig').mockRejectedValue(new Error('OIDC failed'));
+    const cb = jest.fn();
+
+    await authenticator.completeAuth(cb);
+
+    expect(cb).toHaveBeenCalledWith(new Error('OIDC failed'));
+    expect(window.sessionStorage.getItem(CODE_VERIFIER_STORAGE_KEY)).toBeNull();
+  });
+
+  it('should clear code verifier when nonce validation fails', async () => {
+    const expectedNonce = setValidNonce('expected-nonce');
+    const state = encodeURIComponent(JSON.stringify({ nonce: `${expectedNonce}-other` }));
+    setAuthCallbackUrl(`?code=auth-code&state=${state}`);
+    window.sessionStorage.setItem(CODE_VERIFIER_STORAGE_KEY, 'verifier');
+
+    const authenticator = new PkceAuthenticator({
+      use_oidc: false,
+      base_url: 'https://example.com',
+      auth_endpoint: 'authorize',
+      auth_token_endpoint: 'oauth/token',
+      auth_token_endpoint_content_type: 'application/json',
+      app_id: 'app-id',
+    });
+    const cb = jest.fn();
+
+    await authenticator.completeAuth(cb);
+
+    expect(cb).toHaveBeenCalledWith(new Error('Invalid nonce'));
+    expect(window.sessionStorage.getItem(CODE_VERIFIER_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/packages/decap-cms-lib-auth/src/__tests__/utils.spec.js
+++ b/packages/decap-cms-lib-auth/src/__tests__/utils.spec.js
@@ -1,0 +1,24 @@
+import { createNonce, validateNonce } from '../utils';
+
+describe('auth utils', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+  });
+
+  it('should validate and clear nonce from session storage', () => {
+    const nonce = createNonce();
+
+    expect(validateNonce(nonce)).toBe(true);
+    expect(window.sessionStorage.getItem('decap-cms-auth')).toBeNull();
+  });
+
+  it('should not clear local storage nonce key', () => {
+    window.localStorage.setItem('decap-cms-auth', 'local-only');
+    const nonce = createNonce();
+
+    validateNonce(nonce);
+
+    expect(window.localStorage.getItem('decap-cms-auth')).toBe('local-only');
+  });
+});

--- a/packages/decap-cms-lib-auth/src/pkce-oauth.js
+++ b/packages/decap-cms-lib-auth/src/pkce-oauth.js
@@ -146,10 +146,12 @@ export default class PkceAuthenticator {
 
     const validNonce = validateNonce(nonce);
     if (!validNonce) {
+      clearCodeVerifier();
       return cb(new Error('Invalid nonce'));
     }
 
     if (params.has('error')) {
+      clearCodeVerifier();
       return cb(new Error(`${params.get('error')}: ${params.get('error_description')}`));
     }
 
@@ -157,6 +159,7 @@ export default class PkceAuthenticator {
       try {
         await this._loadOidcConfig();
       } catch (err) {
+        clearCodeVerifier();
         return cb(err);
       }
 

--- a/packages/decap-cms-lib-auth/src/utils.js
+++ b/packages/decap-cms-lib-auth/src/utils.js
@@ -9,7 +9,7 @@ export function createNonce() {
 export function validateNonce(check) {
   const auth = window.sessionStorage.getItem('decap-cms-auth');
   const valid = auth && JSON.parse(auth).nonce;
-  window.localStorage.removeItem('decap-cms-auth');
+  window.sessionStorage.removeItem('decap-cms-auth');
   return check === valid;
 }
 

--- a/packages/decap-cms-widget-markdown/src/MarkdownControl/plugins/html/__tests__/withHtml.spec.js
+++ b/packages/decap-cms-widget-markdown/src/MarkdownControl/plugins/html/__tests__/withHtml.spec.js
@@ -1,0 +1,67 @@
+import { Transforms } from 'slate';
+
+import withHtml from '../withHtml';
+
+describe('withHtml', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function createEditor() {
+    return {
+      insertData: jest.fn(),
+      isInline: jest.fn(() => false),
+      isVoid: jest.fn(() => false),
+    };
+  }
+
+  function createDataTransfer(html) {
+    return {
+      getData: jest.fn(type => (type === 'text/html' ? html : '')),
+    };
+  }
+
+  it('should unwrap links with dangerous protocols', () => {
+    const editor = withHtml(createEditor());
+    const insertFragmentSpy = jest.spyOn(Transforms, 'insertFragment').mockImplementation(() => {});
+
+    editor.insertData(createDataTransfer('<p><a href="javascript:alert(1)">click me</a></p>'));
+
+    expect(insertFragmentSpy).toHaveBeenCalledWith(editor, [
+      {
+        type: 'paragraph',
+        children: [{ text: 'click me' }],
+      },
+    ]);
+  });
+
+  it('should drop images with dangerous protocols', () => {
+    const editor = withHtml(createEditor());
+    const insertFragmentSpy = jest.spyOn(Transforms, 'insertFragment').mockImplementation(() => {});
+
+    editor.insertData(createDataTransfer('<p>before<img src="javascript:alert(1)">after</p>'));
+
+    expect(insertFragmentSpy).toHaveBeenCalledWith(editor, [
+      {
+        type: 'paragraph',
+        children: [{ text: 'beforeafter' }],
+      },
+    ]);
+  });
+
+  it('should keep safe image URLs', () => {
+    const editor = withHtml(createEditor());
+    const insertFragmentSpy = jest.spyOn(Transforms, 'insertFragment').mockImplementation(() => {});
+
+    editor.insertData(createDataTransfer('<p><img src="https://example.com/image.png"></p>'));
+
+    expect(insertFragmentSpy).toHaveBeenCalledWith(editor, [
+      {
+        type: 'paragraph',
+        children: [
+          { type: 'image', url: 'https://example.com/image.png', children: [{ text: '' }] },
+        ],
+      },
+    ]);
+  });
+});

--- a/packages/decap-cms-widget-markdown/src/MarkdownControl/plugins/html/withHtml.js
+++ b/packages/decap-cms-widget-markdown/src/MarkdownControl/plugins/html/withHtml.js
@@ -1,9 +1,43 @@
 // source: https://github.com/ianstormtaylor/slate/blob/main/site/examples/ts/paste-html.tsx
+import DOMPurify from 'dompurify';
 import { jsx } from 'slate-hyperscript';
 import { Transforms } from 'slate';
 
+function sanitizeElementUrl(url, { allowDataImage = false } = {}) {
+  if (!url) {
+    return null;
+  }
+
+  const trimmed = url.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  const normalized = trimmed.replace(/\s+/g, '').toLowerCase();
+
+  if (
+    normalized.startsWith('javascript:') ||
+    normalized.startsWith('vbscript:') ||
+    normalized.startsWith('file:')
+  ) {
+    return null;
+  }
+
+  if (normalized.startsWith('data:')) {
+    return allowDataImage && /^data:image\/(?!svg\+xml)[a-z0-9.+-]+[;,]/i.test(normalized)
+      ? trimmed
+      : null;
+  }
+
+  return trimmed;
+}
+
 const ELEMENT_TAGS = {
-  A: el => ({ type: 'link', url: el.getAttribute('href') }),
+  A: el => {
+    const url = sanitizeElementUrl(el.getAttribute('href'));
+    return url ? { type: 'link', url } : undefined;
+  },
   BLOCKQUOTE: () => ({ type: 'quote' }),
   H1: () => ({ type: 'heading-one' }),
   H2: () => ({ type: 'heading-two' }),
@@ -11,7 +45,10 @@ const ELEMENT_TAGS = {
   H4: () => ({ type: 'heading-four' }),
   H5: () => ({ type: 'heading-five' }),
   H6: () => ({ type: 'heading-six' }),
-  IMG: el => ({ type: 'image', url: el.getAttribute('src') }),
+  IMG: el => {
+    const url = sanitizeElementUrl(el.getAttribute('src'), { allowDataImage: true });
+    return url ? { type: 'image', url } : null;
+  },
   LI: () => ({ type: 'list-item' }),
   OL: () => ({ type: 'numbered-list' }),
   P: () => ({ type: 'paragraph' }),
@@ -62,6 +99,15 @@ function deserialize(el) {
 
   if (ELEMENT_TAGS[nodeName]) {
     const attrs = ELEMENT_TAGS[nodeName](el);
+
+    if (attrs === undefined) {
+      return children;
+    }
+
+    if (attrs === null) {
+      return null;
+    }
+
     return jsx('element', attrs, children);
   }
 
@@ -102,7 +148,8 @@ function withHtml(editor) {
     const html = data.getData('text/html');
 
     if (html) {
-      const parsed = new DOMParser().parseFromString(html, 'text/html');
+      const sanitizedHtml = DOMPurify.sanitize(html);
+      const parsed = new DOMParser().parseFromString(sanitizedHtml, 'text/html');
       const fragment = deserialize(parsed.body);
       Transforms.insertFragment(editor, fragment);
       return;

--- a/packages/decap-cms-widget-markdown/src/MarkdownPreview.js
+++ b/packages/decap-cms-widget-markdown/src/MarkdownPreview.js
@@ -4,6 +4,7 @@ import { WidgetPreviewContainer } from 'decap-cms-ui-default';
 import DOMPurify from 'dompurify';
 
 import { markdownToHtml } from './serializers';
+
 class MarkdownPreview extends React.Component {
   static propTypes = {
     getAsset: PropTypes.func.isRequired,
@@ -23,7 +24,8 @@ class MarkdownPreview extends React.Component {
     }
 
     const html = markdownToHtml(value, { getAsset, resolveWidget }, getRemarkPlugins?.());
-    const toRender = field?.get('sanitize_preview', false) ? DOMPurify.sanitize(html) : html;
+    const shouldSanitizePreview = field?.get('sanitize_preview') ?? true;
+    const toRender = shouldSanitizePreview ? DOMPurify.sanitize(html) : html;
 
     return <WidgetPreviewContainer dangerouslySetInnerHTML={{ __html: toRender }} />;
   }

--- a/packages/decap-cms-widget-markdown/src/__tests__/renderer.spec.js
+++ b/packages/decap-cms-widget-markdown/src/__tests__/renderer.spec.js
@@ -208,6 +208,16 @@ I get 10 times more traffic from [Google] than from [Yahoo] or [MSN].
       expect(img).not.toHaveAttribute('onerror');
     });
 
+    it('should sanitize dangerous link protocols', () => {
+      const value = '<a href="javascript:alert(1)">click</a>';
+
+      const { container } = render(
+        <MarkdownPreview value={value} getAsset={jest.fn()} resolveWidget={jest.fn()} />,
+      );
+      const link = container.querySelector('a');
+      expect(link).not.toHaveAttribute('href');
+    });
+
     it('should not sanitize HTML', async () => {
       const value = `<img src="foobar.png" onerror="alert('hello')">`;
       const field = Map({ sanitize_preview: false });

--- a/packages/decap-cms-widget-richtext/src/RichtextPreview.js
+++ b/packages/decap-cms-widget-richtext/src/RichtextPreview.js
@@ -22,7 +22,8 @@ function RichtextPreview({
     { getAsset, resolveWidget, editorComponents: getEditorComponents?.() },
     getRemarkPlugins?.(),
   );
-  const toRender = field?.get('sanitize_preview', false) ? DOMPurify.sanitize(html) : html;
+  const shouldSanitizePreview = field?.get('sanitize_preview') ?? true;
+  const toRender = shouldSanitizePreview ? DOMPurify.sanitize(html) : html;
 
   // Inject block-specific styles into the iframe
   const previewStyles = `

--- a/packages/decap-cms-widget-richtext/src/__tests__/renderer.spec.js
+++ b/packages/decap-cms-widget-richtext/src/__tests__/renderer.spec.js
@@ -208,6 +208,16 @@ I get 10 times more traffic from [Google] than from [Yahoo] or [MSN].
       expect(img).not.toHaveAttribute('onerror');
     });
 
+    it('should sanitize dangerous link protocols', () => {
+      const value = '<a href="javascript:alert(1)">click</a>';
+
+      const { container } = render(
+        <RichtextPreview value={value} getAsset={jest.fn()} resolveWidget={jest.fn()} />,
+      );
+      const link = container.querySelector('a');
+      expect(link).not.toHaveAttribute('href');
+    });
+
     it('should not sanitize HTML', () => {
       const value = `<img src="foobar.png" onerror="alert('hello')">`;
       const field = Map({ sanitize_preview: false });

--- a/packages/decap-server/README.md
+++ b/packages/decap-server/README.md
@@ -29,6 +29,6 @@ GIT_REPO_DIRECTORY=FULL_PATH_TO_LOCAL_GIT_REPO
 PORT=CUSTOM_PORT
 # optional, only listen for incoming connections on a specific IP address
 BIND_HOST=127.0.0.1
-# optional, restrict API requests to a specific origin
+# optional, restrict API requests to a specific origin. Default is /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/ to allow requests from localhost and 127.0.0.1.
 ORIGIN=https://example.com
 ```

--- a/packages/decap-server/src/middlewares/common/index.ts
+++ b/packages/decap-server/src/middlewares/common/index.ts
@@ -18,7 +18,7 @@ export function registerCommonMiddlewares(app: express.Express, options: Options
   app.use(morgan('combined', { stream }));
   app.use(
     cors({
-      origin: process.env.ORIGIN || '*',
+      origin: process.env.ORIGIN || /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/,
     }),
   );
   app.use(express.json({ limit: '50mb' }));


### PR DESCRIPTION
- Implement HTML sanitization for links and images to prevent unsafe protocols. 

- Improve proxy URL validation to ensure only safe schemes are accepted, along with corresponding tests for these features. 

- Change default for sanitize_preview from false to true

