### PR TITLE
fix(#7794): populate relation widget from url

### DIFF
--- a/packages/decap-cms-core/src/actions/__tests__/entries.spec.js
+++ b/packages/decap-cms-core/src/actions/__tests__/entries.spec.js
@@ -1,4 +1,4 @@
-import { fromJS, Map } from 'immutable';
+import { fromJS, List, Map } from 'immutable';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
@@ -97,6 +97,41 @@ describe('entries', () => {
           type: 'DRAFT_CREATE_EMPTY',
         });
       });
+    });
+
+    it('should populate draft entry from repeated URL param', () => {
+      const store = mockStore({ mediaLibrary: fromJS({ files: [] }) });
+
+      const collection = fromJS({
+        fields: [{ name: 'post', multiple: true }],
+      });
+
+      return store
+        .dispatch(createEmptyDraft(collection, '?post=2026-05-07-test&post=2026-05-08-test'))
+        .then(() => {
+          const actions = store.getActions();
+          expect(actions).toHaveLength(1);
+
+          expect(actions[0]).toEqual({
+            payload: {
+              author: '',
+              collection: undefined,
+              data: { post: List(['2026-05-07-test', '2026-05-08-test']) },
+              meta: {},
+              i18n: {},
+              isModification: null,
+              label: null,
+              mediaFiles: [],
+              partial: false,
+              path: '',
+              raw: '',
+              slug: '',
+              status: '',
+              updatedOn: '',
+            },
+            type: 'DRAFT_CREATE_EMPTY',
+          });
+        });
     });
 
     it('should html escape URL params', () => {

--- a/packages/decap-cms-core/src/actions/entries.ts
+++ b/packages/decap-cms-core/src/actions/entries.ts
@@ -1,9 +1,14 @@
-import { fromJS, List, Map } from 'immutable';
+import { fromJS, List, Map, Set } from 'immutable';
 import isEqual from 'lodash/isEqual';
 import { Cursor } from 'decap-cms-lib-util';
 
 import { selectCollectionEntriesCursor } from '../reducers/cursors';
-import { selectFields, updateFieldByKey, selectDefaultSortField } from '../reducers/collections';
+import {
+  selectFields,
+  selectField,
+  updateFieldByKey,
+  selectDefaultSortField,
+} from '../reducers/collections';
 import { selectIntegration, selectPublishedSlugs } from '../reducers';
 import { getIntegrationProvider } from '../integrations';
 import { currentBackend } from '../backend';
@@ -38,7 +43,6 @@ import type {
 import type { EntryValue } from '../valueObjects/Entry';
 import type { Backend } from '../backend';
 import type AssetProxy from '../valueObjects/AssetProxy';
-import type { Set } from 'immutable';
 
 /*
  * Constant Declarations
@@ -740,10 +744,21 @@ function getMetaFields(fields: EntryFields) {
 export function createEmptyDraft(collection: Collection, search: string) {
   return async (dispatch: ThunkDispatch<State, {}, AnyAction>, getState: () => State) => {
     const params = new URLSearchParams(search);
-    params.forEach((value, key) => {
-      collection = updateFieldByKey(collection, key, field =>
-        field.set('default', processValue(value)),
-      );
+    const uniqueKeys = Set([...params.keys()]).toArray();
+
+    uniqueKeys.forEach(key => {
+      const field = selectField(collection, key);
+      const isMultiple = field?.get('multiple', false);
+      const values = params.getAll(key);
+
+      collection = updateFieldByKey(collection, key, field => {
+        if (isMultiple) {
+          const allValues = values.flatMap(v => v.split(',')).map(processValue);
+          return field.set('default', List(allValues));
+        } else {
+          return field.set('default', processValue(values[values.length - 1]));
+        }
+      });
     });
 
     const fields = collection.get('fields', List());

--- a/packages/decap-cms-core/src/types/redux.ts
+++ b/packages/decap-cms-core/src/types/redux.ts
@@ -596,6 +596,7 @@ export type EntryField = StaticallyTypedRecord<{
   name: string;
   default: string | null | boolean | List<unknown>;
   media_folder?: string;
+  multiple?: boolean;
   public_folder?: string;
   comment?: string;
   meta?: boolean;


### PR DESCRIPTION
The createEmptyDraft action creator didn't combine repeated query params into a List, instead returning the last param. Now relation widgets with isMultiple set will populate correctly. Please let me know when you think this could be deployed as I have an event I'd like to use this feature during on starting the week of the 18th.

closes #7794 

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

I have a collection with a relation widget that needs to pre-populate from query params. This was working fine without isMultiple set to true on the field, but it didn't work if isMultiple was set to true. I changed the action creator responsible for parsing the query params to handle repeated values as Lists.

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

Ran development server and found the following isMultiple: true relation field then entered a repeated post query param. Added a unit test to the relevant action creator.

<img width="1181" height="1061" alt="Screenshot 2026-05-08 at 12 25 04 PM" src="https://github.com/user-attachments/assets/a5d9690f-2b35-4476-aa75-1529055e2129" />


**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).
- [x] Added a relevant test
- [x] Modified documentation [here](https://github.com/decaporg/decap-website/pull/164)

**A picture of a cute animal (not mandatory but encouraged)**

<img width="768" height="1024" alt="6C78CC96-4C23-43CA-A063-CB3BCC6D3AD5_1_105_c" src="https://github.com/user-attachments/assets/8d48cbb8-7426-460c-a549-99cc14497e89" />
