### PR TITLE
feat(ui): make app header responsive

### DIFF
--- a/packages/decap-cms-core/src/components/App/App.js
+++ b/packages/decap-cms-core/src/components/App/App.js
@@ -32,7 +32,6 @@ TopBarProgress.config({
 });
 
 const AppMainContainer = styled.div`
-  min-width: 800px;
   max-width: 1440px;
   margin: 0 auto;
 `;

--- a/packages/decap-cms-core/src/components/App/App.js
+++ b/packages/decap-cms-core/src/components/App/App.js
@@ -155,6 +155,7 @@ class App extends React.Component {
       openMediaLibrary,
       t,
       showMediaButton,
+      location,
     } = this.props;
 
     if (config === null) {
@@ -176,22 +177,30 @@ class App extends React.Component {
     const defaultPath = getDefaultPath(collections);
     const hasWorkflow = publishMode === EDITORIAL_WORKFLOW;
 
+    // Work out if this is an editor route, following the same URL matching as the router.
+    // - /collections/:name/entries/*
+    // - /collections/:name/new
+    const [, base, , view] = location.pathname.split('/');
+    const isEditorRoute = base === 'collections' && (view === 'entries' || view === 'new');
+
     return (
       <>
         <Notifications />
-        <Header
-          user={user}
-          collections={collections}
-          onCreateEntryClick={createNewEntry}
-          onLogoutClick={logoutUser}
-          openMediaLibrary={openMediaLibrary}
-          hasWorkflow={hasWorkflow}
-          displayUrl={config.display_url}
-          logoUrl={config.logo_url} // Deprecated, replaced by `logo.src`
-          logo={config.logo}
-          isTestRepo={config.backend.name === 'test-repo'}
-          showMediaButton={showMediaButton}
-        />
+        {!isEditorRoute && (
+          <Header
+            user={user}
+            collections={collections}
+            onCreateEntryClick={createNewEntry}
+            onLogoutClick={logoutUser}
+            openMediaLibrary={openMediaLibrary}
+            hasWorkflow={hasWorkflow}
+            displayUrl={config.display_url}
+            logoUrl={config.logo_url} // Deprecated, replaced by `logo.src`
+            logo={config.logo}
+            isTestRepo={config.backend.name === 'test-repo'}
+            showMediaButton={showMediaButton}
+          />
+        )}
         <AppMainContainer>
           {isFetching && <TopBarProgress />}
           <Switch>

--- a/packages/decap-cms-core/src/components/App/App.js
+++ b/packages/decap-cms-core/src/components/App/App.js
@@ -32,6 +32,7 @@ TopBarProgress.config({
 });
 
 const AppMainContainer = styled.div`
+  min-width: 800px;
   max-width: 1440px;
   margin: 0 auto;
 `;

--- a/packages/decap-cms-core/src/components/App/Header.js
+++ b/packages/decap-cms-core/src/components/App/Header.js
@@ -11,7 +11,6 @@ import {
   DropdownItem,
   StyledDropdownButton,
   colors,
-  lengths,
   shadows,
   buttons,
   zIndex,
@@ -35,7 +34,6 @@ function AppHeader(props) {
         width: 100%;
         background-color: ${colors.foreground};
         z-index: ${zIndex.zIndex300};
-        height: ${lengths.topBarHeight};
 
         @media (min-height: 500px) {
           position: sticky;

--- a/packages/decap-cms-core/src/components/App/Header.js
+++ b/packages/decap-cms-core/src/components/App/Header.js
@@ -47,7 +47,6 @@ function AppHeader(props) {
 const AppHeaderContent = styled.div`
   display: flex;
   justify-content: space-between;
-  min-width: 800px;
   max-width: 1440px;
   padding: 0 12px;
   margin: 0 auto;

--- a/packages/decap-cms-core/src/components/App/Header.js
+++ b/packages/decap-cms-core/src/components/App/Header.js
@@ -32,12 +32,15 @@ function AppHeader(props) {
     <header
       css={css`
         ${shadows.dropMain};
-        position: sticky;
         width: 100%;
-        top: 0;
         background-color: ${colors.foreground};
         z-index: ${zIndex.zIndex300};
         height: ${lengths.topBarHeight};
+
+        @media (min-height: 500px) {
+          position: sticky;
+          top: 0;
+        }
       `}
       {...props}
     />

--- a/packages/decap-cms-core/src/components/App/Header.js
+++ b/packages/decap-cms-core/src/components/App/Header.js
@@ -47,10 +47,15 @@ function AppHeader(props) {
 
 const AppHeaderContent = styled.div`
   display: flex;
-  justify-content: space-between;
-  max-width: 1440px;
+  flex-direction: column-reverse;
   padding: 0 12px;
   margin: 0 auto;
+
+  @media (min-width: 800px) {
+    max-width: 1440px;
+    flex-direction: row;
+    justify-content: space-between;
+  }
 `;
 
 const AppHeaderButton = styled.button`
@@ -58,14 +63,27 @@ const AppHeaderButton = styled.button`
   background: none;
   color: #7b8290;
   font-family: inherit;
-  font-size: 16px;
+  font-size: 13px;
+  line-height: 1;
   font-weight: 500;
   display: inline-flex;
-  padding: 16px 20px;
+  flex-direction: column;
+  gap: 2px;
+  padding: 0 10px 10px;
   align-items: center;
+  text-align: center;
+
+  @media (min-width: 400px) {
+    flex-direction: row;
+    gap: 4px;
+  }
+
+  @media (min-width: 500px) {
+    font-size: 16px;
+    padding: 16px 20px;
+  }
 
   ${Icon} {
-    margin-right: 4px;
     color: #b3b9c4;
   }
 
@@ -93,14 +111,16 @@ const AppHeaderButton = styled.button`
 const AppHeaderNavLink = AppHeaderButton.withComponent(NavLink);
 
 const AppHeaderActions = styled.div`
-  display: inline-flex;
+  display: flex;
   align-items: center;
+  justify-content: space-between;
 `;
 
 const AppHeaderQuickNewButton = styled(StyledDropdownButton)`
   ${buttons.button};
   ${buttons.medium};
   ${buttons.gray};
+  white-space: nowrap;
   margin-right: 8px;
 
   &:after {
@@ -112,6 +132,11 @@ const AppHeaderNavList = styled.ul`
   display: flex;
   margin: 0;
   list-style: none;
+  justify-content: space-around;
+
+  @media (min-width: 800px) {
+    justify-content: flex-start;
+  }
 `;
 
 const AppHeaderLogo = styled.li`

--- a/packages/decap-cms-core/src/components/UI/SettingsDropdown.js
+++ b/packages/decap-cms-core/src/components/UI/SettingsDropdown.js
@@ -3,7 +3,14 @@ import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { translate } from 'react-polyglot';
-import { Icon, Dropdown, DropdownItem, DropdownButton, colors } from 'decap-cms-ui-default';
+import {
+  Icon,
+  Dropdown,
+  DropdownItem,
+  DropdownButton,
+  colors,
+  shadows,
+} from 'decap-cms-ui-default';
 
 import { stripProtocol } from '../../lib/urlHelper';
 
@@ -33,21 +40,32 @@ const AvatarPlaceholderIcon = styled(Icon)`
   background-color: ${colors.textFieldBorder};
 `;
 
-const AppHeaderSiteLink = styled.a`
+const AppHeaderLink = css`
   font-size: 14px;
   font-weight: 400;
-  color: #7b8290;
+  color: ${colors.text};
   padding: 10px 16px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 `;
 
+const AppHeaderSiteLink = styled.a(AppHeaderLink);
+
 const AppHeaderTestRepoIndicator = styled.a`
-  font-size: 14px;
-  font-weight: 400;
-  color: #7b8290;
-  padding: 10px 16px;
+  ${AppHeaderLink};
+
+  @media (max-width: 399px) {
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 12px;
+    background-color: ${colors.background};
+    padding: 4px 12px;
+    border-radius: 0 0 4px 4px;
+    ${shadows.drop}
+  }
 `;
 
 function Avatar({ imageUrl }) {

--- a/packages/decap-cms-core/src/components/UI/SettingsDropdown.js
+++ b/packages/decap-cms-core/src/components/UI/SettingsDropdown.js
@@ -38,6 +38,9 @@ const AppHeaderSiteLink = styled.a`
   font-weight: 400;
   color: #7b8290;
   padding: 10px 16px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 const AppHeaderTestRepoIndicator = styled.a`
@@ -59,9 +62,15 @@ Avatar.propTypes = {
   imageUrl: PropTypes.string,
 };
 
+const SettingsWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  min-width: 0;
+`;
+
 function SettingsDropdown({ displayUrl, isTestRepo, imageUrl, onLogoutClick, t }) {
   return (
-    <React.Fragment>
+    <SettingsWrapper>
       {isTestRepo && (
         <AppHeaderTestRepoIndicator
           href="https://www.decapcms.org/docs/test-backend"
@@ -88,7 +97,7 @@ function SettingsDropdown({ displayUrl, isTestRepo, imageUrl, onLogoutClick, t }
       >
         <DropdownItem label={t('ui.settingsDropdown.logOut')} onClick={onLogoutClick} />
       </Dropdown>
-    </React.Fragment>
+    </SettingsWrapper>
   );
 }
 


### PR DESCRIPTION
**Summary**

Similarly to #7820, this PR aims to tackle a small portion of the work to make the app dashboard responsive, keeping the focus small and incremental. In this case, it tackles the app header.

I borrowed some of the design ideas from #7298, but tried to avoid too many font-size changes so that UI elements continue to share the same font sizes.

- Wraps the app header onto two lines in smaller viewports.

- Hides the app header on editor routes so it doesn’t peek below the editor header (similar to #7298).

- Allows the site link URL to be truncated as the viewport shrinks. In general, truncation can be a bad approach for UI because, for example, truncating the label of an action can mislead a user (e.g. imagine truncating “Delete all” to “Delete…”), but in this case I think it may be acceptable because it’s the site URL not a UI string and at most viewport widths, enough of the URL should remain visible to be understood.

- At the smallest viewport widths, brings the navigation labels under the icons to allow an even more compact horizontal display.

- The app header is no longer sticky, for viewports <500px tall. This also an accessibility change as well as related to responsiveness: it ensures on small viewports or for users who zoom the interface, the app header doesn’t get in the way, taking up too much of the screen. (Related to [WCAG Success Criterion 1.4.4](https://www.w3.org/WAI/WCAG21/Understanding/resize-text.html).)

- Not important on production sites, but I also added a style for the test backend indicator for the smallest viewport. It’s a bit of a kludge, but given this is an indicator that the site is in test mode rather than a genuine part of the CMS UI, I think it’s OK for it to appear in this “overlay” position to let the “real” layout of the app header display at small viewport sizes.

Here’s an example of the header layout reflowing at various viewport widths:

https://github.com/user-attachments/assets/9438062f-209e-4492-9fa1-6d52b7dec0d4

With the English UI strings it works down to 235px wide. I checked a few other languages and most seemed similar. Some languages use two-word phrases on the navigation buttons like “Flujo Editorial” for “Workflow” in Spanish. At the smallest viewport sizes, these wrap, e.g.

| 250px | 350px |
|---|---|
| <img width="248" height="128" alt="image" src="https://github.com/user-attachments/assets/303411db-5577-4e25-a02e-292a61b2ba62" /> | <img width="347" height="111" alt="image" src="https://github.com/user-attachments/assets/9a3542af-6a0c-48c7-8bad-50f47dd79c81" /> |



**Test plan**

Tested locally at a range of viewport sizes and app states. Existing tests should pass as this mostly touches styling.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
