### PR TITLE
feat(ui): make dropdown positioning responsive

### DIFF
--- a/packages/decap-cms-core/src/components/Editor/__tests__/__snapshots__/EditorToolbar.spec.js.snap
+++ b/packages/decap-cms-core/src/components/Editor/__tests__/__snapshots__/EditorToolbar.spec.js.snap
@@ -106,6 +106,7 @@ exports[`EditorToolbar should render normal save button 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  touch-action: manipulation;
   margin: 0 10px;
 }
 
@@ -127,6 +128,7 @@ exports[`EditorToolbar should render normal save button 1`] = `
   padding-left: 20px;
   padding-right: 40px;
   position: relative;
+  white-space: nowrap;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -245,15 +247,17 @@ exports[`EditorToolbar should render normal save button 1`] = `
           <div
             class="emotion-14 emotion-15 emotion-16"
           >
-            <span
-              aria-expanded="false"
-              aria-haspopup="true"
-              class="emotion-17 emotion-18"
-              role="button"
-              tabindex="0"
-            >
-              editor.editorToolbar.publish
-            </span>
+            <div>
+              <span
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="emotion-17 emotion-18"
+                role="button"
+                tabindex="0"
+              >
+                editor.editorToolbar.publish
+              </span>
+            </div>
           </div>
         </div>
         <div>
@@ -383,6 +387,7 @@ exports[`EditorToolbar should render normal save button 2`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  touch-action: manipulation;
   margin: 0 10px;
 }
 
@@ -404,6 +409,7 @@ exports[`EditorToolbar should render normal save button 2`] = `
   padding-left: 20px;
   padding-right: 40px;
   position: relative;
+  white-space: nowrap;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -522,15 +528,17 @@ exports[`EditorToolbar should render normal save button 2`] = `
           <div
             class="emotion-14 emotion-15 emotion-16"
           >
-            <span
-              aria-expanded="false"
-              aria-haspopup="true"
-              class="emotion-17 emotion-18"
-              role="button"
-              tabindex="0"
-            >
-              editor.editorToolbar.publish
-            </span>
+            <div>
+              <span
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="emotion-17 emotion-18"
+                role="button"
+                tabindex="0"
+              >
+                editor.editorToolbar.publish
+              </span>
+            </div>
           </div>
         </div>
         <div>
@@ -927,6 +935,7 @@ exports[`EditorToolbar should render with status=draft,useOpenAuthoring=false 1`
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  touch-action: manipulation;
   margin: 0 10px;
 }
 
@@ -948,6 +957,7 @@ exports[`EditorToolbar should render with status=draft,useOpenAuthoring=false 1`
   padding-left: 20px;
   padding-right: 40px;
   position: relative;
+  white-space: nowrap;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -1072,15 +1082,17 @@ exports[`EditorToolbar should render with status=draft,useOpenAuthoring=false 1`
         <div
           class="emotion-16 emotion-17 emotion-18"
         >
-          <span
-            aria-expanded="false"
-            aria-haspopup="true"
-            class="emotion-19 emotion-20"
-            role="button"
-            tabindex="0"
-          >
-            editor.editorToolbar.status
-          </span>
+          <div>
+            <span
+              aria-expanded="false"
+              aria-haspopup="true"
+              class="emotion-19 emotion-20"
+              role="button"
+              tabindex="0"
+            >
+              editor.editorToolbar.status
+            </span>
+          </div>
         </div>
         <button
           class="emotion-21 emotion-22"
@@ -1238,6 +1250,7 @@ exports[`EditorToolbar should render with status=draft,useOpenAuthoring=true 1`]
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  touch-action: manipulation;
   margin: 0 10px;
 }
 
@@ -1259,6 +1272,7 @@ exports[`EditorToolbar should render with status=draft,useOpenAuthoring=true 1`]
   padding-left: 20px;
   padding-right: 40px;
   position: relative;
+  white-space: nowrap;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -1417,15 +1431,17 @@ exports[`EditorToolbar should render with status=draft,useOpenAuthoring=true 1`]
         <div
           class="emotion-16 emotion-17 emotion-18"
         >
-          <span
-            aria-expanded="false"
-            aria-haspopup="true"
-            class="emotion-19 emotion-20"
-            role="button"
-            tabindex="0"
-          >
-            editor.editorToolbar.status
-          </span>
+          <div>
+            <span
+              aria-expanded="false"
+              aria-haspopup="true"
+              class="emotion-19 emotion-20"
+              role="button"
+              tabindex="0"
+            >
+              editor.editorToolbar.status
+            </span>
+          </div>
         </div>
         <div
           class="emotion-21 emotion-22"
@@ -1610,6 +1626,7 @@ exports[`EditorToolbar should render with status=pending_publish,useOpenAuthorin
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  touch-action: manipulation;
   margin: 0 10px;
 }
 
@@ -1631,6 +1648,7 @@ exports[`EditorToolbar should render with status=pending_publish,useOpenAuthorin
   padding-left: 20px;
   padding-right: 40px;
   position: relative;
+  white-space: nowrap;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -1755,15 +1773,17 @@ exports[`EditorToolbar should render with status=pending_publish,useOpenAuthorin
         <div
           class="emotion-16 emotion-17 emotion-18"
         >
-          <span
-            aria-expanded="false"
-            aria-haspopup="true"
-            class="emotion-19 emotion-20"
-            role="button"
-            tabindex="0"
-          >
-            editor.editorToolbar.status
-          </span>
+          <div>
+            <span
+              aria-expanded="false"
+              aria-haspopup="true"
+              class="emotion-19 emotion-20"
+              role="button"
+              tabindex="0"
+            >
+              editor.editorToolbar.status
+            </span>
+          </div>
         </div>
         <button
           class="emotion-21 emotion-22"
@@ -1921,6 +1941,7 @@ exports[`EditorToolbar should render with status=pending_publish,useOpenAuthorin
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  touch-action: manipulation;
   margin: 0 10px;
 }
 
@@ -1942,6 +1963,7 @@ exports[`EditorToolbar should render with status=pending_publish,useOpenAuthorin
   padding-left: 20px;
   padding-right: 40px;
   position: relative;
+  white-space: nowrap;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -2082,15 +2104,17 @@ exports[`EditorToolbar should render with status=pending_publish,useOpenAuthorin
         <div
           class="emotion-16 emotion-17 emotion-18"
         >
-          <span
-            aria-expanded="false"
-            aria-haspopup="true"
-            class="emotion-19 emotion-20"
-            role="button"
-            tabindex="0"
-          >
-            editor.editorToolbar.status
-          </span>
+          <div>
+            <span
+              aria-expanded="false"
+              aria-haspopup="true"
+              class="emotion-19 emotion-20"
+              role="button"
+              tabindex="0"
+            >
+              editor.editorToolbar.status
+            </span>
+          </div>
         </div>
         <div
           class="emotion-21 emotion-22"
@@ -2270,6 +2294,7 @@ exports[`EditorToolbar should render with status=pending_review,useOpenAuthoring
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  touch-action: manipulation;
   margin: 0 10px;
 }
 
@@ -2291,6 +2316,7 @@ exports[`EditorToolbar should render with status=pending_review,useOpenAuthoring
   padding-left: 20px;
   padding-right: 40px;
   position: relative;
+  white-space: nowrap;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -2415,15 +2441,17 @@ exports[`EditorToolbar should render with status=pending_review,useOpenAuthoring
         <div
           class="emotion-16 emotion-17 emotion-18"
         >
-          <span
-            aria-expanded="false"
-            aria-haspopup="true"
-            class="emotion-19 emotion-20"
-            role="button"
-            tabindex="0"
-          >
-            editor.editorToolbar.status
-          </span>
+          <div>
+            <span
+              aria-expanded="false"
+              aria-haspopup="true"
+              class="emotion-19 emotion-20"
+              role="button"
+              tabindex="0"
+            >
+              editor.editorToolbar.status
+            </span>
+          </div>
         </div>
         <button
           class="emotion-21 emotion-22"
@@ -2581,6 +2609,7 @@ exports[`EditorToolbar should render with status=pending_review,useOpenAuthoring
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  touch-action: manipulation;
   margin: 0 10px;
 }
 
@@ -2602,6 +2631,7 @@ exports[`EditorToolbar should render with status=pending_review,useOpenAuthoring
   padding-left: 20px;
   padding-right: 40px;
   position: relative;
+  white-space: nowrap;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -2760,15 +2790,17 @@ exports[`EditorToolbar should render with status=pending_review,useOpenAuthoring
         <div
           class="emotion-16 emotion-17 emotion-18"
         >
-          <span
-            aria-expanded="false"
-            aria-haspopup="true"
-            class="emotion-19 emotion-20"
-            role="button"
-            tabindex="0"
-          >
-            editor.editorToolbar.status
-          </span>
+          <div>
+            <span
+              aria-expanded="false"
+              aria-haspopup="true"
+              class="emotion-19 emotion-20"
+              role="button"
+              tabindex="0"
+            >
+              editor.editorToolbar.status
+            </span>
+          </div>
         </div>
         <div
           class="emotion-21 emotion-22"

--- a/packages/decap-cms-ui-default/src/DropDown/getCoords.js
+++ b/packages/decap-cms-ui-default/src/DropDown/getCoords.js
@@ -1,0 +1,68 @@
+/** @typedef {'left' | 'right' | 'center' | undefined} Position */
+
+/**
+ * Calculate relative co-ordinates for a dropdown to position it below a reference element.
+ * @param {{ reference: DOMRect; target: DOMRect; viewport: DOMRect; dropdownPosition: Position }} options
+ */
+export function getCoords({ reference, target, dropdownPosition, viewport }) {
+  let { x, y } = computeCoordsFromPlacement({ reference, target, dropdownPosition });
+  ({ x, y } = constrain({ x, y, viewport, target }));
+  return relativize({ x, y, reference });
+}
+
+/**
+ * @param {{ reference: DOMRect; target: DOMRect; dropdownPosition: Position }} options
+ * @returns {{ x: number; y: number }} co-ordinates
+ */
+function computeCoordsFromPlacement({ reference, target, dropdownPosition }) {
+  const commonAlign = reference.width / 2 - target.width / 2;
+
+  const coords = {
+    x: reference.x + commonAlign,
+    y: reference.y + reference.height,
+  };
+
+  switch (dropdownPosition) {
+    case 'left':
+      coords.x -= commonAlign;
+      break;
+    case 'right':
+      coords.x += commonAlign;
+      break;
+    default:
+  }
+
+  return coords;
+}
+
+/**
+ * Constrain co-ordinates within the viewport.
+ * @param {{ x: number; y: number, viewport: DOMRect, target: DOMRect }} options
+ */
+function constrain({ x, y, viewport, target }) {
+  const overflow = {
+    left: x,
+    right: x + target.width - viewport.width,
+  };
+
+  x = clamp(x - overflow.left, x, x - overflow.right);
+
+  return { x, y };
+}
+
+/**
+ * @param {number} min
+ * @param {number} value
+ * @param {number} max
+ */
+function clamp(min, value, max) {
+  return Math.min(Math.max(min, value), max);
+}
+
+/**
+ * Convert absolute viewport co-ordinates into element-relative co-ordinates.
+ * @param {{ x: number; y: number; reference: DOMRect }} options
+ */
+function relativize({ x, y, reference }) {
+  return { x: x - reference.x, y: y - reference.y };
+}

--- a/packages/decap-cms-ui-default/src/DropDown/useDropDownCoords.js
+++ b/packages/decap-cms-ui-default/src/DropDown/useDropDownCoords.js
@@ -21,7 +21,7 @@ function onResize([entry]) {
  * We cache this single observer to avoid the overhead of creating a new one for every dropdown.
  */
 function initObserver() {
-  if (!viewportState.observer) {
+  if (!viewportState.observer && typeof ResizeObserver !== 'undefined') {
     viewportState.observer = new ResizeObserver(onResize);
     viewportState.observer.observe(document.documentElement);
   }

--- a/packages/decap-cms-ui-default/src/DropDown/useDropDownCoords.js
+++ b/packages/decap-cms-ui-default/src/DropDown/useDropDownCoords.js
@@ -1,0 +1,110 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+
+import { getCoords } from './getCoords';
+
+/**
+ * @type {{ callbacks: Map<Function, Function>; observer?: ResizeObserver; viewport?: DOMRect; raf?: number }}
+ */
+const viewportState = { callbacks: new Map() };
+
+/** @type {ResizeObserverCallback} */
+function onResize([entry]) {
+  viewportState.viewport = entry.contentRect;
+  if (viewportState.raf) cancelAnimationFrame(viewportState.raf);
+  viewportState.raf = requestAnimationFrame(() => {
+    viewportState.callbacks.forEach(cb => cb(viewportState.viewport));
+  });
+}
+
+/**
+ * Initializes a `ResizeObserver` to track viewport changes and notify subscribers.
+ * We cache this single observer to avoid the overhead of creating a new one for every dropdown.
+ */
+function initObserver() {
+  if (!viewportState.observer) {
+    viewportState.observer = new ResizeObserver(onResize);
+    viewportState.observer.observe(document.documentElement);
+  }
+}
+
+/**
+ * Registers a callback to be called with the viewport rect on changes.
+ * @param {(viewport: DOMRect | undefined) => void} callback
+ * @returns {() => void} An unsubscribe function to stop listening for viewport changes.
+ */
+function subscribeToViewportRect(callback) {
+  initObserver();
+  callback(viewportState.viewport);
+  viewportState.callbacks.set(callback, callback);
+
+  // Unsubscribe function that cleans up the callback and also the observer if no-one is listening anymore.
+  return () => {
+    viewportState.callbacks.delete(callback);
+    if (viewportState.callbacks.size === 0 && viewportState.observer) {
+      viewportState.observer.disconnect();
+      delete viewportState.observer;
+    }
+  };
+}
+
+/** React hook providing the DOMRect of the viewport. */
+function useViewportRect() {
+  const [viewport, setViewport] = useState(/** @type {DOMRect | undefined} */ (undefined));
+  useEffect(() => subscribeToViewportRect(setViewport), []);
+  return viewport;
+}
+
+/**
+ * Get co-ordinates for a dropdown based on its source element and the viewport.
+ * @param {{ dropdownPosition?: import('./getCoords').Position; open?: boolean }} options
+ *
+ * @example
+ * const [open, setOpen] = useState(false);
+ * const { refs, coords } = useDropDownCoords({ dropdownPosition: 'right', open });
+ *
+ * return (
+ *   <div style={{ position: 'relative' }}>
+ *     // Pass the source ref to the button to attach to.
+ *     <button ref={refs.source} onClick={() => setOpen(!open)}>
+ *       Open Dropdown
+ *     </button>
+ *     <ul
+ *       // Pass the dropdown ref to the dropdown menu to measure it.
+ *       ref={refs.dropdown}
+ *       style={{
+ *         position: 'absolute',
+ *         // Use the calculated co-ordinates to position the dropdown.
+ *         left: coords.x,
+ *         top: coords.y,
+ *         display: open ? 'block' : 'none'
+ *       }}>
+ *       ...
+ *     </ul>
+ *   </div>
+ * );
+ */
+export function useDropDownCoords({ dropdownPosition = 'left', open } = {}) {
+  const [x, setX] = useState(0);
+  const [y, setY] = useState(0);
+  const viewport = useViewportRect();
+  const source = useRef(/** @type {HTMLElement | null} */ (null));
+  const dropdown = useRef(/** @type {HTMLElement | null} */ (null));
+
+  useLayoutEffect(() => {
+    if (!open || !viewport || !source.current || !dropdown.current) {
+      return;
+    }
+
+    const { x, y } = getCoords({
+      reference: source.current.getBoundingClientRect(),
+      target: dropdown.current.getBoundingClientRect(),
+      viewport,
+      dropdownPosition,
+    });
+
+    setX(x);
+    setY(y);
+  }, [dropdownPosition, source.current, dropdown.current, viewport, open]);
+
+  return { refs: { source, dropdown }, coords: { x, y } };
+}

--- a/packages/decap-cms-ui-default/src/Dropdown.js
+++ b/packages/decap-cms-ui-default/src/Dropdown.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -93,7 +93,7 @@ function Dropdown({
   className,
   children,
 }) {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = useState(false);
   const { coords, refs } = useDropDownCoords({ dropdownPosition, open });
   return (
     <StyledWrapper

--- a/packages/decap-cms-ui-default/src/Dropdown.js
+++ b/packages/decap-cms-ui-default/src/Dropdown.js
@@ -4,6 +4,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { Wrapper, Button as DropdownButton, Menu, MenuItem } from 'react-aria-menubutton';
 
+import { useDropDownCoords } from './DropDown/useDropDownCoords';
 import { colors, buttons, components, zIndex } from './styles';
 import Icon from './Icon';
 
@@ -11,6 +12,7 @@ const StyledWrapper = styled(Wrapper)`
   position: relative;
   font-size: 14px;
   user-select: none;
+  touch-action: manipulation;
 `;
 
 const StyledDropdownButton = styled(DropdownButton)`
@@ -20,6 +22,7 @@ const StyledDropdownButton = styled(DropdownButton)`
   padding-left: 20px;
   padding-right: 40px;
   position: relative;
+  white-space: nowrap;
 
   &:after {
     ${components.caretDown};
@@ -44,8 +47,7 @@ const DropdownList = styled.ul`
   ${props => css`
     width: ${props.width};
     top: ${props.top};
-    left: ${props.position === 'left' ? 0 : 'auto'};
-    right: ${props.position === 'right' ? 0 : 'auto'};
+    left: ${props.left};
   `};
 `;
 
@@ -91,15 +93,23 @@ function Dropdown({
   className,
   children,
 }) {
+  const [open, setOpen] = React.useState(false);
+  const { coords, refs } = useDropDownCoords({ dropdownPosition, open });
   return (
     <StyledWrapper
       closeOnSelection={closeOnSelection}
       onSelection={handler => handler()}
+      onMenuToggle={({ isOpen }) => setOpen(isOpen)}
       className={className}
     >
-      {renderButton()}
+      <div ref={refs.source}>{renderButton()}</div>
       <Menu>
-        <DropdownList width={dropdownWidth} top={dropdownTopOverlap} position={dropdownPosition}>
+        <DropdownList
+          ref={refs.dropdown}
+          width={dropdownWidth}
+          top={dropdownTopOverlap}
+          left={coords.x + 'px'}
+        >
           {children}
         </DropdownList>
       </Menu>


### PR DESCRIPTION
**Summary**

This PR continues #7820, #7825, and #7827.

It makes the positioning of dropdown menus responsive by ensuring they remain within the viewport.

For example, here’s a dropdown in the collections UI from #7827 demonstrating how this PR fixes the overflow:

| Before | After |
|---|---|
| <img width="293" height="400" alt="image" src="https://github.com/user-attachments/assets/2f7ca3ce-66bf-4242-9f46-246a8dc1adfb" /> | <img width="296" height="382" alt="image" src="https://github.com/user-attachments/assets/2a8f1bd5-017e-45c5-afa2-77583d406aee" /> |

The implementation works by calculating the dropdown position for the desired left/right placement, and then shifting it along the x-axis if needed to ensure it remains within the viewport. (Within reason, at a narrow enough viewport, the dropdown can overflow on both sides, at which point there’s not much more to do. But Decap does not contain any very wide dropdowns, so this scenario can be ignored I think.) For most viewports, there is no change and menus are displayed as before. But for small viewports this approach fixes things.

It is heavily inspired by [Floating UI’s API](https://floating-ui.com/docs/useFloating) and the hook added in this PR is roughly equivalent to:

```jsx
import { useFloating, shift } from '@floating-ui/react-dom';

// Inside component
const { refs, floatingStyles } =  useFloating({ middleware: [shift] });
```

Decap’s needs are quite simple though, so I preferred to roll my own, minimal implementation, which is significantly smaller and less complex than Floating UI. I did a quick check to make sure the size benefits justified owning the code. The bundle size of this implementation is ~1.6 kB (753 B gzip) vs ~13.8 kB (5.52 kB gzip) for Floating UI. Add on the 500 kB install size of `@floating-ui/react-dom` and I think the benefits are pretty clear.

**Test plan**

Existing tests pass and I manually tested the positioning using the local dev environment. If you want, I guess it’s possible to add an E2E test that would use a small viewport and assert that clicking a dropdown shows its contents within the viewport, but I haven’t added that currently.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
