### PR TITLE
Request GitLab LFS content for raw file reads

### DIFF
--- a/packages/decap-cms-backend-gitlab/src/API.ts
+++ b/packages/decap-cms-backend-gitlab/src/API.ts
@@ -346,12 +346,12 @@ export default class API {
   readFile = async (
     path: string,
     sha?: string | null,
-    { parseText = true, branch = this.branch } = {},
+    { parseText = true, branch = this.branch, lfs = true } = {},
   ): Promise<string | Blob> => {
     const fetchContent = async () => {
       const content = await this.request({
         url: `${this.repoURL}/repository/files/${encodeURIComponent(path)}/raw`,
-        params: { ref: branch },
+        params: { ref: branch, ...(lfs ? { lfs: true } : {}) },
         cache: 'no-store',
       }).then<Blob | string>(parseText ? this.responseToText : this.responseToBlob);
       return content;

--- a/packages/decap-cms-backend-gitlab/src/__tests__/API.spec.js
+++ b/packages/decap-cms-backend-gitlab/src/__tests__/API.spec.js
@@ -184,4 +184,37 @@ describe('GitLab API', () => {
       expect(getMaxAccess(groups)).toBe(groups[2]);
     });
   });
+
+  describe('readFile', () => {
+    it('should request Git LFS content from GitLab raw file responses by default', async () => {
+      const api = new API({ repo: 'repo' });
+      const response = {};
+      api.request = jest.fn().mockResolvedValue(response);
+      api.responseToText = jest.fn().mockReturnValue('file content');
+
+      await expect(api.readFile('static/image.png')).resolves.toBe('file content');
+
+      expect(api.request).toHaveBeenCalledTimes(1);
+      expect(api.request).toHaveBeenCalledWith({
+        url: '/projects/repo/repository/files/static%2Fimage.png/raw',
+        params: { ref: 'master', lfs: true },
+        cache: 'no-store',
+      });
+      expect(api.responseToText).toHaveBeenCalledWith(response);
+    });
+
+    it('should allow callers to disable Git LFS content requests', async () => {
+      const api = new API({ repo: 'repo' });
+      api.request = jest.fn().mockResolvedValue({});
+      api.responseToText = jest.fn().mockReturnValue('pointer content');
+
+      await api.readFile('static/image.png', null, { lfs: false });
+
+      expect(api.request).toHaveBeenCalledWith({
+        url: '/projects/repo/repository/files/static%2Fimage.png/raw',
+        params: { ref: 'master' },
+        cache: 'no-store',
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- request GitLab raw file responses with `lfs=true` so LFS-tracked media returns object contents instead of pointer text
- keep an opt-out for callers that explicitly need raw pointer content
- add GitLab backend unit coverage for the default and opt-out request parameters

Fixes #3704.

## Tests
- `npx jest --runTestsByPath packages/decap-cms-backend-gitlab/src/__tests__/API.spec.js --runInBand --no-cache`
- `npm run type-check -- --pretty false`
- `npx eslint packages/decap-cms-backend-gitlab/src/API.ts packages/decap-cms-backend-gitlab/src/__tests__/API.spec.js`
- `npx prettier --check packages/decap-cms-backend-gitlab/src/API.ts packages/decap-cms-backend-gitlab/src/__tests__/API.spec.js`
- `git diff --check`
