### PR TITLE
fix(gitlab): use Bearer auth scheme for GraphQL requests

### DIFF
--- a/packages/decap-cms-backend-gitlab/src/API.ts
+++ b/packages/decap-cms-backend-gitlab/src/API.ts
@@ -243,7 +243,7 @@ export default class API {
         headers: {
           'Content-Type': 'application/json; charset=utf-8',
           ...headers,
-          authorization: this.token ? `token ${this.token}` : '',
+          authorization: this.token ? `Bearer ${this.token}` : '',
         },
       };
     });


### PR DESCRIPTION
# Summary

Fixes #7611

With the GitLab backend and `use_graphql: true`, every GraphQL query comes back as `{"data":{"project":null}}` even though the same query works in Postman or the GitLab GraphiQL explorer.

Root cause: the Apollo client sends the auth header using GitHub's scheme:

```
authorization: token <access_token>
```

GitLab doesn't recognize that scheme, so it silently treats the request as anonymous and returns `null` for any private project. The REST code path a few lines below already uses `Authorization: Bearer <token>` correctly, the GraphQL header just looks copied over from the GitHub backend.

One line change: use `Bearer` for GraphQL too.

This also explains the reporter's observation that requests worked in a browser with CORS disabled: their logged-in GitLab session cookie was doing the authentication, not the header.

## Test plan

- gitlab backend test suite passes (33/33)
- manually traced both code paths: REST (`withAuthorizationHeaders`) and GraphQL (`getApolloClient`) now send the same scheme
