### PR TITLE
fix(richtext): preserve block images in list items

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,8 @@
 module.exports = {
   setupFilesAfterEnv: ['<rootDir>/setupTestFramework.js'],
   moduleNameMapper: {
+    '^platejs/react$': '<rootDir>/node_modules/platejs/dist/react/index.js',
+    '^(@platejs/.+)/react$': '<rootDir>/node_modules/$1/dist/react/index.js',
     'decap-cms-lib-auth': '<rootDir>/packages/decap-cms-lib-auth/src/index.js',
     'decap-cms-lib-util': '<rootDir>/packages/decap-cms-lib-util/src/index.ts',
     'decap-cms-ui-default': '<rootDir>/packages/decap-cms-ui-default/src/index.js',
@@ -13,7 +15,7 @@ module.exports = {
   modulePathIgnorePatterns: ['.nx', 'dist'],
   snapshotSerializers: ['@emotion/jest/serializer'],
   transformIgnorePatterns: [
-    'node_modules/(?!copy-text-to-clipboard|clean-stack|escape-string-regexp)',
+    'node_modules/(?!.*(?:copy-text-to-clipboard|clean-stack|escape-string-regexp|jotai-optics|nanoid))',
   ],
   testEnvironment: 'jsdom',
   testEnvironmentOptions: {

--- a/packages/decap-cms-widget-richtext/src/RichtextControl/VisualEditor.js
+++ b/packages/decap-cms-widget-richtext/src/RichtextControl/VisualEditor.js
@@ -8,7 +8,6 @@ import {
   CodePlugin,
   HeadingPlugin,
 } from '@platejs/basic-nodes/react';
-import { ListPlugin } from '@platejs/list-classic/react';
 import { LinkPlugin } from '@platejs/link/react';
 import { ClassNames, css } from '@emotion/react';
 import { fonts, lengths, zIndex } from 'decap-cms-ui-default';
@@ -28,6 +27,7 @@ import LinkElement from './components/Element/LinkElement';
 import ImageElement from './components/Element/ImageElement';
 import ExtendedBlockquotePlugin from './plugins/ExtendedBlockquotePlugin';
 import ImagePlugin from './plugins/ImagePlugin';
+import ListPlugin from './plugins/ListPlugin';
 import BreakPlugin from './plugins/BreakPlugin';
 import ShortcodePlugin from './plugins/ShortcodePlugin';
 import { TablePlugin, TableRowPlugin, TableCellPlugin } from './plugins/TablePlugin';

--- a/packages/decap-cms-widget-richtext/src/RichtextControl/__tests__/VisualEditor.spec.js
+++ b/packages/decap-cms-widget-richtext/src/RichtextControl/__tests__/VisualEditor.spec.js
@@ -1,8 +1,29 @@
 import { Map, fromJS } from 'immutable';
+import { createPlateEditor, ParagraphPlugin } from 'platejs/react';
 
+import image from '../../../../decap-cms-editor-component-image/src';
+import { markdownToSlate, slateToMarkdown } from '../../serializers';
 import { mergeMediaConfig } from '../mergeMediaConfig';
+import ListPlugin from '../plugins/ListPlugin';
+import ShortcodePlugin from '../plugins/ShortcodePlugin';
 
 describe('VisualEditor', () => {
+  it('should preserve block images inside list items', () => {
+    const markdown = `1. First step.
+2. Last step.
+
+   ![Screenshot](/img/screenshot.png)`;
+    const editorComponents = Map({ image });
+    const value = markdownToSlate(markdown, { editorComponents });
+    const editor = createPlateEditor({
+      plugins: [ParagraphPlugin, ListPlugin, ShortcodePlugin],
+      shouldNormalizeEditor: true,
+      value,
+    });
+
+    expect(slateToMarkdown(editor.children, {}, editorComponents)).toEqual(markdown);
+  });
+
   describe('mergeMediaConfig', () => {
     it('should copy editor media settings to image component', () => {
       const editorComponents = Map({

--- a/packages/decap-cms-widget-richtext/src/RichtextControl/plugins/ListPlugin.js
+++ b/packages/decap-cms-widget-richtext/src/RichtextControl/plugins/ListPlugin.js
@@ -1,0 +1,7 @@
+import { ListPlugin } from '@platejs/list-classic/react';
+
+export default ListPlugin.configure({
+  options: {
+    validLiChildrenTypes: ['shortcode'],
+  },
+});


### PR DESCRIPTION
## Summary

Fixes #7895.

Configure Plate's classic list plugin to accept `shortcode` children. Decap represents block editor components, including the built-in image component, as shortcode nodes. Without this configuration, Plate's list normalizer removes an image nested in a list item when the visual editor initializes, and the next save persists that data loss.

This change:

- preserves block images nested in list items;
- adds a regression test for the Markdown parse, normalize, and serialize round trip;
- maps Plate's React entry points in Jest and allows the nested ESM dependencies needed by that test.

## Reproduction

Opening and saving this Markdown in the rich-text editor:

```md
1. First step.
2. Last step.

   ![Screenshot](/img/screenshot.png)
```

previously produced:

```md
1. First step.
2.
```

The regression test fails with that exact output before the fix and preserves the original Markdown after the fix.

## Test plan

- [x] `npx jest packages/decap-cms-widget-richtext/src/RichtextControl/VisualEditor.spec.js --runInBand`
- [x] `npx jest packages/decap-cms-widget-richtext --runInBand`
- [x] `npm run format`
- [x] `npm run test`
- [x] `npm run build`

## Checklist

- [x] I have read the contribution guidelines.
- [x] I have added a regression test for the bug fix.
- [x] I have linked the issue fixed by this pull request.
