### PR TITLE
fix: bump incompatible react-tostify version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28436,25 +28436,16 @@
       }
     },
     "node_modules/react-toastify": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.3.tgz",
-      "integrity": "sha512-fPfb8ghtn/XMxw3LkxQBk3IyagNpF/LIKjOBflbexr2AWxAH1MJgvnESwEwBn9liLFXgTKWgBSdZpw9m4OTHTg==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.6.tgz",
+      "integrity": "sha512-yYjp+omCDf9lhZcrZHKbSq7YMuK0zcYkDFTzfRFgTXkTFHZ1ToxwAonzA4JI5CxA91JpjFLmwEsZEgfYfOqI1A==",
       "license": "MIT",
       "dependencies": {
-        "clsx": "^1.1.1"
+        "clsx": "^2.1.0"
       },
       "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/react-toastify/node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/react-topbar-progress-indicator": {
@@ -35296,7 +35287,7 @@
         "react-router-dom": "^5.2.0",
         "react-scroll-sync": "^0.11.2",
         "react-split-pane": "^0.1.85",
-        "react-toastify": "^9.1.1",
+        "react-toastify": "^10.0.6",
         "react-topbar-progress-indicator": "^4.0.0",
         "react-virtualized-auto-sizer": "^1.0.2",
         "react-waypoint": "^10.0.0",

--- a/packages/decap-cms-core/package.json
+++ b/packages/decap-cms-core/package.json
@@ -55,7 +55,7 @@
     "react-router-dom": "^5.2.0",
     "react-scroll-sync": "^0.11.2",
     "react-split-pane": "^0.1.85",
-    "react-toastify": "^9.1.1",
+    "react-toastify": "^10.0.6",
     "react-topbar-progress-indicator": "^4.0.0",
     "react-virtualized-auto-sizer": "^1.0.2",
     "react-waypoint": "^10.0.0",

--- a/packages/decap-cms-core/src/components/UI/Notifications.tsx
+++ b/packages/decap-cms-core/src/components/UI/Notifications.tsx
@@ -70,7 +70,13 @@ function Notifications({ notifications }: Props) {
 
   return (
     <>
-      <ToastContainer position="top-right" theme="colored" className="notif__container" />
+      <ToastContainer
+        position="top-right"
+        theme="colored"
+        className="notif__container"
+        closeOnClick
+        draggable
+      />
     </>
   );
 }

--- a/packages/decap-cms-core/src/components/UI/__tests__/Notifications.spec.js
+++ b/packages/decap-cms-core/src/components/UI/__tests__/Notifications.spec.js
@@ -1,0 +1,33 @@
+import { act, render, screen } from '@testing-library/react';
+import { I18n } from 'react-polyglot';
+import { Provider } from 'react-redux';
+import { toast } from 'react-toastify';
+import configureStore from 'redux-mock-store';
+
+import Notifications from '../Notifications';
+
+const mockStore = configureStore([]);
+
+describe('Notifications', () => {
+  afterEach(() => {
+    act(() => toast.dismiss());
+  });
+
+  it('renders a success notification', async () => {
+    const store = mockStore({
+      notifications: {
+        notifications: [{ id: '1', message: 'Entry saved', type: 'success' }],
+      },
+    });
+
+    render(
+      <Provider store={store}>
+        <I18n locale="en" messages={{}}>
+          <Notifications />
+        </I18n>
+      </Provider>,
+    );
+
+    expect(await screen.findByText('Entry saved')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines here:
https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

This PR bumps the react-tostify version to one compatible with React's new automatic JSX runtime. This was actually breaking toasts for users and causing React errors.

Closes #7900

**Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**Checklist**

Please add a `x` inside each checkbox:

- [ ] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).

**A picture of a cute animal (not mandatory but encouraged)**
