### PR TITLE
fix: Windows path-mock regression and media library upload/delete edge case

### DIFF
--- a/packages/decap-cms-core/src/components/MediaLibrary/MediaLibrary.js
+++ b/packages/decap-cms-core/src/components/MediaLibrary/MediaLibrary.js
@@ -97,7 +97,7 @@ class MediaLibrary extends React.Component {
 
     if (this.state.isPersisted) {
       this.setState({
-        selectedFile: nextProps.files[0],
+        selectedFile: nextProps.files[0] || {},
         isPersisted: false,
       });
     }
@@ -112,7 +112,7 @@ class MediaLibrary extends React.Component {
 
     if (this.state.isPersisted) {
       this.setState({
-        selectedFile: this.props.files[0],
+        selectedFile: this.props.files[0] || {},
         isPersisted: false,
       });
     }

--- a/packages/decap-cms-core/src/components/MediaLibrary/MediaLibraryTop.js
+++ b/packages/decap-cms-core/src/components/MediaLibrary/MediaLibraryTop.js
@@ -61,7 +61,7 @@ function MediaLibraryTop({
   hasSelection,
   isPersisting,
   isDeleting,
-  selectedFile,
+  selectedFile = {},
 }) {
   const shouldShowButtonLoader = isPersisting || isDeleting;
   const uploadEnabled = !shouldShowButtonLoader;

--- a/packages/decap-cms-core/src/reducers/mediaLibrary.ts
+++ b/packages/decap-cms-core/src/reducers/mediaLibrary.ts
@@ -191,7 +191,7 @@ function mediaLibrary(state = Map(defaultState), action: MediaLibraryAction) {
       }
       return state.withMutations(map => {
         const fileWithKey = { ...file, key: crypto.randomUUID() };
-        const files = map.get('files') as MediaFile[];
+        const files = (map.get('files') as MediaFile[]) || [];
         const updatedFiles = [fileWithKey, ...files];
         map.set('files', updatedFiles);
         map.set('isPersisting', false);

--- a/packages/decap-server/src/middlewares/utils/fs.spec.ts
+++ b/packages/decap-server/src/middlewares/utils/fs.spec.ts
@@ -1,3 +1,5 @@
+jest.unmock('path');
+
 import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';

--- a/packages/decap-server/src/middlewares/utils/fs.ts
+++ b/packages/decap-server/src/middlewares/utils/fs.ts
@@ -36,8 +36,6 @@ export async function listRepoFiles(
   try {
     resolvedFolder = await resolveExistingRepoPath(repoRoot, folder);
   } catch (e) {
-    // The folder may not exist yet (e.g. no content or media has been
-    // created), which just means there are no files to list.
     if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
       return [];
     }

--- a/packages/decap-server/src/middlewares/utils/fs.ts
+++ b/packages/decap-server/src/middlewares/utils/fs.ts
@@ -31,7 +31,20 @@ export async function listRepoFiles(
   depth: number,
 ) {
   const repoRoot = await fs.realpath(path.resolve(repoPath));
-  const files = await listFiles(await resolveExistingRepoPath(repoRoot, folder), extension, depth);
+
+  let resolvedFolder: string;
+  try {
+    resolvedFolder = await resolveExistingRepoPath(repoRoot, folder);
+  } catch (e) {
+    // The folder may not exist yet (e.g. no content or media has been
+    // created), which just means there are no files to list.
+    if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
+      return [];
+    }
+    throw e;
+  }
+
+  const files = await listFiles(resolvedFolder, extension, depth);
   return files.map(f => path.relative(repoRoot, f));
 }
 


### PR DESCRIPTION
- Unmock the `path` module in `fs.spec.ts` so decap-server's filesystem security-boundary tests use real OS path semantics — the global POSIX `path` mock (meant for CMS content-path parsing) broke Windows drive-letter   resolution and made these tests fail on `windows-latest`.
- Guard `MediaLibrary`'s post-upload auto-select against an empty file list, which crashed the app with `Cannot read properties of undefined (reading 'path')` right after uploading to the global media library.
- Make decap-server's `listRepoFiles` tolerate a media/content folder that doesn't exist yet (a normal state for a brand new site) instead of surfacing it as a 500.

## Test plan
- [x] `packages/decap-server` unit tests pass (incl. `fs.spec.ts` on the
      Windows CI runner)
- [x] `decap-cms-core` media library reducer/component tests pass
- [x] Reproduced both bugs locally against a real decap-server + browser and
      confirmed upload/delete now work with no console errors
- [x] Full CI run green on all platforms and e2e shards
