### PR TITLE
fix(widget-list): route list item changes by item id, not position

### DIFF
--- a/packages/decap-cms-widget-list/src/ListControl.js
+++ b/packages/decap-cms-widget-list/src/ListControl.js
@@ -419,20 +419,32 @@ export default class ListControl extends Component {
   getObjectValue = idx => this.props.value.get(idx) || Map();
 
   handleChangeFor(index) {
+    const key = this.state.keys[index];
+
     return (f, newValue, newMetadata) => {
       const { value, metadata, onChange, field } = this.props;
+
+      // Resolve the item's position when the change fires rather than when this
+      // handler was created. If an item has been removed or moved in between,
+      // `index` now points at a different item, or past the end of the list.
+      const currentIndex = this.state.keys.indexOf(key);
+
+      if (currentIndex === -1) {
+        return;
+      }
+
       const collectionName = field.get('name');
       const listFieldObjectWidget = field.getIn(['field', 'widget']) === 'object';
       const withNameKey =
         this.getValueType() !== valueTypes.SINGLE ||
         (this.getValueType() === valueTypes.SINGLE && listFieldObjectWidget);
       const newObjectValue = withNameKey
-        ? this.getObjectValue(index).set(f.get('name'), newValue)
+        ? this.getObjectValue(currentIndex).set(f.get('name'), newValue)
         : newValue;
       const parsedMetadata = {
         [collectionName]: Object.assign(metadata ? metadata.toJS() : {}, newMetadata || {}),
       };
-      onChange(value.set(index, newObjectValue), parsedMetadata);
+      onChange(value.set(currentIndex, newObjectValue), parsedMetadata);
     };
   }
 

--- a/packages/decap-cms-widget-list/src/__tests__/ListControl.spec.js
+++ b/packages/decap-cms-widget-list/src/__tests__/ListControl.spec.js
@@ -786,4 +786,77 @@ describe('ListControl', () => {
     listControl.validate();
     expect(props.onValidateObject).toHaveBeenCalledWith('forID', []);
   });
+
+  const typedField = fromJS({
+    name: 'list',
+    label: 'List',
+    types: [
+      {
+        name: 'type_one',
+        widget: 'object',
+        fields: [{ name: 'text', widget: 'markdown', label: 'Text' }],
+      },
+    ],
+  });
+
+  it('should apply a change to the item it was made on after an earlier item is removed', () => {
+    const value = fromJS([
+      { type: 'type_one', text: 'one' },
+      { type: 'type_one', text: 'two' },
+      { type: 'type_one', text: 'three' },
+    ]);
+
+    let control;
+    const { getAllByText, rerender } = render(
+      <ListControl ref={ref => (control = ref)} {...props} field={typedField} value={value} />,
+    );
+
+    const changeThirdItem = control.handleChangeFor(2);
+
+    fireEvent.click(getAllByText('Remove')[0]);
+    const afterRemoval = props.onChange.mock.calls[0][0];
+    rerender(
+      <ListControl
+        ref={ref => (control = ref)}
+        {...props}
+        field={typedField}
+        value={afterRemoval}
+      />,
+    );
+
+    changeThirdItem(fromJS({ name: 'text' }), 'three edited');
+
+    const written = props.onChange.mock.calls[1][0].toJS();
+    expect(written).toHaveLength(2);
+    expect(written[1]).toEqual({ type: 'type_one', text: 'three edited' });
+  });
+
+  it('should discard a change made on an item that has since been removed', () => {
+    const value = fromJS([
+      { type: 'type_one', text: 'one' },
+      { type: 'type_one', text: 'two' },
+    ]);
+
+    let control;
+    const { getAllByText, rerender } = render(
+      <ListControl ref={ref => (control = ref)} {...props} field={typedField} value={value} />,
+    );
+
+    const changeSecondItem = control.handleChangeFor(1);
+
+    fireEvent.click(getAllByText('Remove')[1]);
+    const afterRemoval = props.onChange.mock.calls[0][0];
+    rerender(
+      <ListControl
+        ref={ref => (control = ref)}
+        {...props}
+        field={typedField}
+        value={afterRemoval}
+      />,
+    );
+
+    changeSecondItem(fromJS({ name: 'text' }), 'text for a removed item');
+
+    expect(props.onChange).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
**Summary**

Changes to a list item are recorded against the item's position in the list rather than the item itself. If an item is removed or reordered before a change is applied, that change lands on the wrong item. When the position no longer exists, `getObjectValue` returns an empty `Map`, so the change becomes a *new* item containing only the field that was edited — and with `types` configured, that item has no type key.

This resolves the position from the item's id in `state.keys` at the moment the change fires, which is what `SortableList` already does via `keys.indexOf`. A change belonging to an item that has since been removed is dropped, as there is nothing left to apply it to.

Three reported behaviours share this cause:

- **An item with no type.** Type into the third item, remove the first without saving, type into the last item again, then save. The saved entry gains an item holding only the edited field. Anything mapping items to components by type then fails — in our case a static site build.
- **Content overwritten.** Reorder two items and type into one. The edit lands on whichever item now occupies that position, and the text it replaced is lost. Nothing errors.
- **A preview that appears to freeze.** The same thing seen from the other side: the item being edited is not the item on screen, so the visible one never updates. This is what #7956 originally described.

Reproduced on 3.15.1 and on `main`, using a `list` widget with `types` where each type has a markdown field of the same name.

Fixes #7956.

**Test plan**

Two tests added to `packages/decap-cms-widget-list/src/__tests__/ListControl.spec.js`. They reuse the file's shared `props`, the mocked top bar's Remove button (so the real removal path runs), and the existing sequential `crypto.randomUUID` mock.

Without the change, both fail:

```
$ NODE_ENV=test npx jest packages/decap-cms-widget-list

✕ should apply a change to the item it was made on after an earlier item is removed
✕ should discard a change made on an item that has since been removed

  Expected length: 2
  Received length: 3
  Received array:  [{"text": "two", "type": "type_one"}, {"text": "three", "type": "type_one"}, {"text": "three edited"}]

Tests: 2 failed, 29 passed, 31 total
```

The third entry is the malformed item: no `type`, and its text is a copy of the item above plus the keystrokes that arrived after the removal.

With the change, the package suite and the full unit suite both pass, with no snapshot updates:

```
$ NODE_ENV=test npx jest packages/decap-cms-widget-list
Tests:       31 passed, 31 total
Snapshots:   11 passed, 11 total

$ pnpm run test
Test Suites: 2 skipped, 110 passed, 110 of 112 total
Tests:       1304 skipped, 1351 passed, 2655 total
Snapshots:   138 passed, 138 total
```

**Checklist**

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).
