### PR TITLE
fix: support Forgejo editorial workflow PR heads

### DIFF
--- a/packages/decap-cms-backend-forgejo/src/API.ts
+++ b/packages/decap-cms-backend-forgejo/src/API.ts
@@ -587,14 +587,21 @@ export default class API {
 
     return pullRequests.filter(pr => {
       const label = pr.head?.label;
-      if (label) {
-        return label === head;
-      }
       const repoOwner = pr.head?.repo?.owner?.login;
       const ref = pr.head?.ref;
+
+      if (label === head) {
+        return true;
+      }
       if (repoOwner && ref) {
         return `${repoOwner}:${ref}` === head;
       }
+
+      // Forgejo may return a branch-only label for same-repository PRs.
+      if (ref) {
+        return `${this.repoOwner}:${ref}` === head;
+      }
+
       return false;
     });
   }

--- a/packages/decap-cms-backend-forgejo/src/__tests__/API.spec.js
+++ b/packages/decap-cms-backend-forgejo/src/__tests__/API.spec.js
@@ -688,6 +688,23 @@ describe('forgejo API', () => {
       });
     });
 
+    it('should match pull request by ref when head label does not include the owner', async () => {
+      const api = new API({ branch: 'gh-pages', repo: 'owner/my-repo', token: 'token' });
+      api.requestAllPages = jest.fn().mockResolvedValue([
+        {
+          number: 1,
+          head: { label: 'cms/new-branch', ref: 'cms/new-branch' },
+        },
+      ]);
+
+      await expect(api.getPullRequests('open', 'owner:cms/new-branch')).resolves.toEqual([
+        {
+          number: 1,
+          head: { label: 'cms/new-branch', ref: 'cms/new-branch' },
+        },
+      ]);
+    });
+
     it('should list unpublished branches (standard mode)', async () => {
       const api = new API({
         branch: 'gh-pages',


### PR DESCRIPTION
**Summary**

Fixes #7949.

Forgejo can return pull request heads with a branch-only `head.label`, such as `cms/new-branch`, instead of the owner-qualified format expected by Decap CMS. This caused newly created editorial workflow entries to be missing from the workflow pane and produced repeated `content is not under editorial workflow` errors.

The Forgejo backend now also matches same-repository pull requests using `head.ref` with the configured repository owner when the label does not include the owner. Added regression coverage for this response shape.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).
