### PR TITLE
fix(release): verify published manifests, widen catalog: guard

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,5 +76,27 @@ jobs:
           echo "::endgroup::"
 
       - name: Publish to npm
-        run: pnpm run publish:packages -- --provenance
+        # The OIDC token exchange fails intermittently (ERR_PNPM_AUTH_TOKEN_EXCHANGE),
+        # which used to leave the release half-published until a maintainer noticed
+        # and re-ran the workflow by hand. `pnpm publish -r` skips versions that are
+        # already on the registry, so retrying is safe and resumes where it stopped.
         # No NODE_AUTH_TOKEN needed - uses OIDC automatically via trusted publishers
+        run: |
+          for attempt in 1 2 3; do
+            echo "::group::Publish attempt $attempt"
+            if pnpm run publish:packages -- --provenance; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            echo "Publish attempt $attempt failed, retrying in 30s..."
+            sleep 30
+          done
+          echo "::error::pnpm publish failed after 3 attempts"
+          exit 1
+
+      # Must run after publishing: a pre-publish check only sees what the correct
+      # publish client produces, so it cannot catch a release uploaded by a client
+      # that does not understand `catalog:`. See issue #7979.
+      - name: Verify published manifests
+        run: pnpm run verify:published

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,7 +204,16 @@ Decap CMS uses NPM trusted publishers with OIDC for secure, automated package pu
 - Uses OpenID Connect (OIDC) for authentication. No NPM tokens required
 - Each package has a trusted publisher configured on npmjs.com
 - Workflow generates short-lived, cryptographically-signed tokens automatically
-- Publishes all changed packages in the monorepo via Lerna
+- Lerna bumps versions and tags; **`pnpm publish -r` does the publishing**
+
+> [!IMPORTANT]
+> **Never run `lerna publish` (in any form, including `from-git` and `from-package`).**
+>
+> Package manifests declare their dependencies as `catalog:`, a pnpm-workspace-internal protocol that has to be substituted with the real semver ranges at publish time. `pnpm publish` does that substitution; Lerna's publish client does not, and uploads the literal string `catalog:` to the registry. The result installs fine with pnpm inside this workspace and is broken for every consumer using npm, yarn or bun.
+>
+> This is what happened in the 2026-09-08 release: eight packages, including `decap-server@3.11.1`, shipped uninstallable. See [#7979](https://github.com/decaporg/decap-cms/issues/7979).
+>
+> Use `lerna version` to bump and tag. Publishing is CI's job, and `pnpm run publish:packages` is the only manual fallback.
 
 ### Release Process
 
@@ -228,10 +237,19 @@ Decap CMS uses NPM trusted publishers with OIDC for secure, automated package pu
 2. **Automated publishing:**
    - Tags pushed to `main` trigger the publish workflow automatically
    - GitHub Actions runs tests and builds packages
-   - Lerna publishes changed packages to npm using OIDC
+   - `pnpm publish -r` publishes changed packages to npm using OIDC
    - Provenance attestations are generated automatically
+   - The workflow retries the publish step, then verifies every published manifest
 
-3. **Create GitHub release:**
+3. **Verify the release:**
+   ```sh
+   git pull
+   pnpm run verify:published
+   ```
+
+   The publish workflow runs this too, but run it locally as well after any release that needed manual intervention. It fetches every publishable package from the registry at the version in your working tree and fails if a published manifest still contains `catalog:` or `workspace:` specifiers.
+
+4. **Create GitHub release:**
    - Go to [Releases](https://github.com/decaporg/decap-cms/releases)
    - Draft a new release from the tag
    - Add release notes highlighting changes
@@ -244,11 +262,16 @@ If automated publishing fails and you need to publish manually:
 # Authenticate with npm (uses session-based auth with 2FA)
 npm login
 
-# Publish changed packages
+# Publish changed packages -- pnpm, never lerna, see the warning above
 pnpm run publish:packages
+
+# Always confirm what actually reached the registry
+pnpm run verify:published
 ```
 
 Note: Manual publishing still requires 2FA. Use recovery codes if you don't have access to your 2FA device.
+
+`pnpm publish -r` skips versions that are already on the registry, so it is safe to re-run against a partially published release.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "format:prettier": "prettier \"{{packages,scripts}/**/,}*.{js,jsx,ts,tsx,css}\"",
     "prepare": "husky install",
     "publish:packages": "pnpm publish -r --no-git-checks --report-summary",
-    "test:package-integrity": "node scripts/test-package-integrity.mjs"
+    "test:package-integrity": "node scripts/test-package-integrity.mjs",
+    "verify:published": "node scripts/verify-published-packages.mjs"
   },
   "browserslist": [
     "last 2 Chrome versions",

--- a/scripts/test-package-integrity.mjs
+++ b/scripts/test-package-integrity.mjs
@@ -19,7 +19,11 @@ import { join } from 'path';
 import { gunzipSync } from 'zlib';
 
 const ROOT_DIR = process.cwd();
-const PACKAGES_TO_TEST = ['decap-cms', 'decap-cms-core', 'decap-cms-app'];
+// The browser-bundle and package.json-shape checks only make sense for the
+// browser entry points. The publish-protocol check runs over every publishable
+// package -- scoping it to a hardcoded few is what let decap-server ship with
+// unresolved `catalog:` specifiers (issue #7979).
+const BROWSER_PACKAGES = ['decap-cms', 'decap-cms-core', 'decap-cms-app'];
 const DEPENDENCY_FIELDS = [
   'dependencies',
   'devDependencies',
@@ -66,6 +70,29 @@ function readFileFromTarball(tarballPath, targetPath) {
   }
 
   throw new Error(`Missing ${targetPath} in ${tarballPath}`);
+}
+
+/**
+ * Every non-private package in the pnpm workspace, i.e. exactly the set that
+ * `pnpm publish -r` uploads.
+ */
+function getPublishablePackages() {
+  // Passed as a single string: spawnSync warns (DEP0190) when args are combined
+  // with `shell: true`, and the shell is needed to resolve pnpm on Windows.
+  const result = spawnSync('pnpm list -r --depth -1 --json', {
+    encoding: 'utf8',
+    stdio: 'pipe',
+    shell: true,
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`pnpm list failed: ${result.stderr || result.stdout}`);
+  }
+
+  return JSON.parse(result.stdout)
+    .filter(pkg => pkg.name && !pkg.private)
+    .map(({ name, path }) => ({ name, dir: path }))
+    .sort((a, b) => a.name.localeCompare(b.name));
 }
 
 function findPublishProtocolDependencies(manifest) {
@@ -136,9 +163,7 @@ function checkDistForNodeProtocol(packageDir) {
 /**
  * Test that a package can be packed without errors
  */
-function testPackagePack(packageName) {
-  const packageDir = join(ROOT_DIR, 'packages', packageName);
-
+function testPackagePack(packageName, packageDir) {
   log(`Testing pnpm pack for ${packageName}...`);
 
   const packDir = mkdtempSync(join(tmpdir(), `decap-pack-${packageName}-`));
@@ -252,14 +277,22 @@ async function main() {
 
   let allPassed = true;
 
-  for (const packageName of PACKAGES_TO_TEST) {
+  const publishablePackages = getPublishablePackages();
+  log(`\n=== Checking packed manifests for ${publishablePackages.length} publishable packages ===`);
+
+  for (const { name, dir } of publishablePackages) {
+    if (!testPackagePack(name, dir)) {
+      allPassed = false;
+    }
+  }
+
+  for (const packageName of BROWSER_PACKAGES) {
     log(`\n=== Testing ${packageName} ===`);
 
-    const packOk = testPackagePack(packageName);
     const browserOk = testBrowserCompatibility(packageName);
     const pkgJsonOk = testPackageJson(packageName);
 
-    if (!packOk || !browserOk || !pkgJsonOk) {
+    if (!browserOk || !pkgJsonOk) {
       allPassed = false;
     }
   }

--- a/scripts/verify-published-packages.mjs
+++ b/scripts/verify-published-packages.mjs
@@ -81,7 +81,10 @@ function delay(ms) {
 }
 
 async function fetchPublishedManifest(registry, name, version) {
-  const url = `${registry}/${name.replace('/', '%2f')}/${version}`;
+  // Scoped names must have their separator encoded to address a single version,
+  // e.g. `@scope/pkg` -> `@scope%2fpkg`. replaceAll, not replace: escaping only
+  // the first occurrence is the js/incomplete-sanitization pattern.
+  const url = `${registry}/${name.replaceAll('/', '%2f')}/${version}`;
 
   for (let attempt = 1; attempt <= FETCH_ATTEMPTS; attempt++) {
     let response;

--- a/scripts/verify-published-packages.mjs
+++ b/scripts/verify-published-packages.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+
+/**
+ * Published Package Verification
+ *
+ * Fetches every publishable workspace package from the npm registry at the
+ * version currently in the working tree, and fails if a published manifest
+ * still carries pnpm-internal `catalog:` / `workspace:` specifiers.
+ *
+ * This runs *after* publishing on purpose. A pre-publish check can only
+ * inspect what the correct publish client produces, so it cannot catch a
+ * release that was uploaded by a client which does not understand
+ * `catalog:` (`lerna publish`, `npm publish`). Only the registry knows what
+ * was actually shipped.
+ *
+ * @see https://github.com/decaporg/decap-cms/issues/7979
+ */
+
+import { spawnSync } from 'child_process';
+
+const DEFAULT_REGISTRY = 'https://registry.npmjs.org';
+const DEPENDENCY_FIELDS = [
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+  'optionalDependencies',
+];
+const PUBLISH_PROTOCOL = /^(catalog|workspace):/;
+const FETCH_ATTEMPTS = 3;
+const FETCH_RETRY_DELAY_MS = 2000;
+
+function log(msg) {
+  console.log(`[verify-published-packages] ${msg}`);
+}
+
+function error(msg) {
+  console.error(`[verify-published-packages] ERROR: ${msg}`);
+}
+
+function parseArgs(argv) {
+  const options = { registry: DEFAULT_REGISTRY, allowMissing: false };
+
+  for (const arg of argv) {
+    if (arg === '--allow-missing') {
+      options.allowMissing = true;
+    } else if (arg.startsWith('--registry=')) {
+      options.registry = arg.slice('--registry='.length);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return { ...options, registry: options.registry.replace(/\/+$/, '') };
+}
+
+/**
+ * Every non-private package in the pnpm workspace, i.e. exactly the set that
+ * `pnpm publish -r` uploads.
+ */
+function getPublishablePackages() {
+  // Passed as a single string: spawnSync warns (DEP0190) when args are combined
+  // with `shell: true`, and the shell is needed to resolve pnpm on Windows.
+  const result = spawnSync('pnpm list -r --depth -1 --json', {
+    encoding: 'utf8',
+    stdio: 'pipe',
+    shell: true,
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`pnpm list failed: ${result.stderr || result.stdout}`);
+  }
+
+  return JSON.parse(result.stdout)
+    .filter(pkg => pkg.name && !pkg.private)
+    .map(({ name, version }) => ({ name, version }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function fetchPublishedManifest(registry, name, version) {
+  const url = `${registry}/${name.replace('/', '%2f')}/${version}`;
+
+  for (let attempt = 1; attempt <= FETCH_ATTEMPTS; attempt++) {
+    let response;
+    try {
+      response = await fetch(url, { headers: { accept: 'application/json' } });
+    } catch (e) {
+      if (attempt === FETCH_ATTEMPTS) {
+        throw new Error(`${name}@${version}: ${e.message}`);
+      }
+      await delay(FETCH_RETRY_DELAY_MS);
+      continue;
+    }
+
+    if (response.status === 404) {
+      return null;
+    }
+
+    if (response.ok) {
+      return response.json();
+    }
+
+    // 5xx and rate limits are worth another try; anything else is not.
+    if (attempt === FETCH_ATTEMPTS || (response.status < 500 && response.status !== 429)) {
+      throw new Error(`${name}@${version}: registry responded ${response.status}`);
+    }
+
+    await delay(FETCH_RETRY_DELAY_MS);
+  }
+
+  throw new Error(`${name}@${version}: exhausted registry retries`);
+}
+
+function findPublishProtocolDependencies(manifest) {
+  const dependenciesWithPublishProtocols = [];
+
+  for (const field of DEPENDENCY_FIELDS) {
+    for (const [dependencyName, specifier] of Object.entries(manifest[field] || {})) {
+      if (typeof specifier === 'string' && PUBLISH_PROTOCOL.test(specifier)) {
+        dependenciesWithPublishProtocols.push(`${field}.${dependencyName}: ${specifier}`);
+      }
+    }
+  }
+
+  return dependenciesWithPublishProtocols;
+}
+
+async function main() {
+  const { registry, allowMissing } = parseArgs(process.argv.slice(2));
+  const packages = getPublishablePackages();
+
+  log(`Verifying ${packages.length} publishable packages against ${registry}`);
+
+  const broken = [];
+  const missing = [];
+
+  for (const { name, version } of packages) {
+    let manifest;
+    try {
+      manifest = await fetchPublishedManifest(registry, name, version);
+    } catch (e) {
+      error(e.message);
+      broken.push({ name, version, issues: [e.message] });
+      continue;
+    }
+
+    if (!manifest) {
+      missing.push({ name, version });
+      log(`  ${name}@${version} is not on the registry`);
+      continue;
+    }
+
+    const issues = findPublishProtocolDependencies(manifest);
+    if (issues.length > 0) {
+      broken.push({ name, version, issues });
+      error(`${name}@${version} published with unresolved pnpm protocols:`);
+      for (const issue of issues) {
+        error(`  ${issue}`);
+      }
+      continue;
+    }
+
+    log(`  ${name}@${version} OK`);
+  }
+
+  log('\n=== Summary ===');
+  log(`verified: ${packages.length - broken.length - missing.length}`);
+  log(`missing:  ${missing.length}`);
+  log(`broken:   ${broken.length}`);
+
+  if (broken.length > 0) {
+    error('\nThese versions are unusable with npm, yarn and bun and must be republished:');
+    for (const { name, version } of broken) {
+      error(`  ${name}@${version}`);
+    }
+    process.exit(1);
+  }
+
+  if (missing.length > 0 && !allowMissing) {
+    error('\nThese versions never reached the registry:');
+    for (const { name, version } of missing) {
+      error(`  ${name}@${version}`);
+    }
+    error('Re-run the publish workflow, or pass --allow-missing when checking before a release.');
+    process.exit(1);
+  }
+
+  log('All published manifests are clean!');
+}
+
+main().catch(e => {
+  error(e.message);
+  process.exit(1);
+});


### PR DESCRIPTION
Fixes the release pipeline hole behind #7979, and closes a much larger hole the issue did not reach.

## What went wrong

The npm registry records the publisher of every version. For the 2026-09-08 release it splits cleanly in two:

| Published (UTC) | `_npmVersion` | Result |
| --- | --- | --- |
| 09:23:56 – 09:27:13 | `lerna/9.0.7/node@v24.11.1+arm64 (darwin)` | 9 packages, **8 broken** |
| 10:04 – 11:18 | `ci/oidc` (`pnpm publish -r`) | 33 packages, all clean |

Manifests declare their deps as `catalog:`, which has to be substituted with real semver ranges at publish time. `pnpm publish` does that; **Lerna's publish client does not** and uploads the literal string. `decap-server@3.11.0` is clean because it predates the pnpm migration.

## It is 8 packages, not 1 — and the whole 3.x line is uninstallable

The issue checked the 5 headline packages. Sweeping all 41:

```
decap-cms-default-exports@3.3.1          decap-cms-lib-util@3.8.1
decap-cms-editor-component-image@3.4.1   decap-cms-lib-widgets@3.4.1
decap-cms-lib-auth@3.3.1                 decap-cms-media-library-cloudinary@3.1.1
decap-server@3.11.1                      decap-cms-media-library-uploadcare@3.1.1
```

Two amplifiers make this far worse than 8 leaf packages, and neither shows up in a top-level manifest:

- `workspace:*` publishes as an **exact** pin (pre-pnpm Lerna used `^`), so **20 of 41** published packages hard-pin a broken version.
- Older releases' caret ranges resolve **forward** into the broken versions.

Verified against the live registry:

```
npm install decap-cms@3.16.1  -> EUNSUPPORTEDPROTOCOL
npm install decap-cms@3.16.0  -> EUNSUPPORTEDPROTOCOL
npm install decap-cms@3.15.0  -> EUNSUPPORTEDPROTOCOL
npm install decap-cms@3.14.0  -> EUNSUPPORTEDPROTOCOL
```

There is currently no `decap-cms` version installable with npm, yarn or bun. Pinning `decap-server` to `3.11.0`, as the issue suggests, does not help anyone installing the CMS itself.

## Why the existing check could not catch it

`test:package-integrity` already contained exactly the right assertion. It still could not have caught this, for two independent reasons:

1. It covered 3 hardcoded packages; `decap-server` was never among them.
2. It packs with `pnpm pack`, which resolves catalogs correctly — so it validates the *good* path.

That second point generalises: **no pre-publish check can catch a release made by the wrong client, because the check runs under the right one.** Only the registry knows what actually shipped.

## Changes

- **`scripts/verify-published-packages.mjs`** (new) — fetches every publishable package from the registry at its working-tree version and fails on any remaining `catalog:` / `workspace:` specifier. Client-agnostic: it checks reality, not intent. Running it against the current registry reproduces the 8 failures exactly.
- **`.github/workflows/publish.yml`** — runs it as a post-publish gate, so a bad release goes red within minutes instead of surfacing as a user bug report the next day. Also retries the publish step: the OIDC token exchange flaked with `ERR_PNPM_AUTH_TOKEN_EXCHANGE` and needed **3 manual re-runs** that day, and that flakiness is exactly the pressure that makes a local publish tempting.
- **`scripts/test-package-integrity.mjs`** — packed-manifest check widened from 3 packages to all 41. Browser-bundle and manifest-shape checks stay scoped to the 3 browser entry points, since `decap-server` legitimately uses `node:` imports.
- **`CONTRIBUTING.md`** — documents that `lerna publish` must never be used, and adds a verification step. Worth noting `lerna.json` cannot enforce this: `from-git` / `from-package` skip Lerna's `allowBranch` guard.

## Follow-up, not in this PR

**Republishing is still required** — this PR only prevents recurrence. Because 3.16.1 exact-pins, the practical fix is one clean full release from CI. Since this PR touches no `packages/*` file, `lerna version` will not bump anything on its own:

```sh
pnpm exec lerna version patch --force-publish
pnpm run verify:published
```

Then `npm deprecate` the 8 bad versions. Republishing the leaf packages alone already un-breaks 3.14–3.16.0 retroactively, since their carets roll forward to the fixed versions.

**Worth deciding separately:** all 105 sibling deps use `workspace:*`, which is why one bad package poisoned 20 others. `workspace:^` restores the pre-pnpm caret behaviour and would contain the next incident, at the cost of the guarantee that the monorepo installs as one tested set. That is a release-policy call, so it is deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
