### PR TITLE
fix(release): add manual publish trigger, tolerate registry lag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'decap-*@*'
+  # GitHub creates no workflow run at all when a push carries many tags at once,
+  # and a release pushes one tag per package (41 in 3.x.2). The tag trigger above
+  # therefore does not fire for a normal release, so publishing needs a manual
+  # entry point. Run it against the release commit; `pnpm publish -r` skips
+  # versions already on the registry, so it is safe to re-run.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,11 +4,6 @@ on:
   push:
     tags:
       - 'decap-*@*'
-  # GitHub creates no workflow run at all when a push carries many tags at once,
-  # and a release pushes one tag per package (41 in 3.x.2). The tag trigger above
-  # therefore does not fire for a normal release, so publishing needs a manual
-  # entry point. Run it against the release commit; `pnpm publish -r` skips
-  # versions already on the registry, so it is safe to re-run.
   workflow_dispatch:
 
 permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,12 +234,15 @@ Decap CMS uses NPM trusted publishers with OIDC for secure, automated package pu
   # - Push to upstream
   ```
 
-2. **Automated publishing:**
-   - Tags pushed to `main` trigger the publish workflow automatically
+2. **Publish:**
+   - Run the **Publish Packages** workflow manually from the Actions tab, against the `chore(release): publish` commit
    - GitHub Actions runs tests and builds packages
    - `pnpm publish -r` publishes changed packages to npm using OIDC
    - Provenance attestations are generated automatically
    - The workflow retries the publish step, then verifies every published manifest
+
+   > [!NOTE]
+   > The workflow also has a tag trigger, but **do not rely on it for a release**. GitHub creates no workflow run at all when a single push carries many tags, and a release pushes one tag per package. Use the manual trigger. `pnpm publish -r` skips versions already on the registry, so re-running it against a partially published release is safe.
 
 3. **Verify the release:**
    ```sh
@@ -248,6 +251,8 @@ Decap CMS uses NPM trusted publishers with OIDC for secure, automated package pu
    ```
 
    The publish workflow runs this too, but run it locally as well after any release that needed manual intervention. It fetches every publishable package from the registry at the version in your working tree and fails if a published manifest still contains `catalog:` or `workspace:` specifiers.
+
+   npm accepts a publish before the version becomes readable, so the check allows up to 10 minutes for absent versions to appear before failing. Unresolved specifiers fail immediately -- that is a property of the published manifest and will not change on its own.
 
 4. **Create GitHub release:**
    - Go to [Releases](https://github.com/decaporg/decap-cms/releases)

--- a/scripts/verify-published-packages.mjs
+++ b/scripts/verify-published-packages.mjs
@@ -28,6 +28,12 @@ const DEPENDENCY_FIELDS = [
 const PUBLISH_PROTOCOL = /^(catalog|workspace):/;
 const FETCH_ATTEMPTS = 3;
 const FETCH_RETRY_DELAY_MS = 2000;
+// npm accepts a publish before the version is readable, and the lag is per
+// package: in the 3.x.2 release one package took ~4 minutes to appear. Without
+// a settle window this gate reports a green publish as a failed release, and a
+// gate that cries wolf gets ignored.
+const PROPAGATION_SETTLE_MS = 10 * 60 * 1000;
+const PROPAGATION_POLL_MS = 15000;
 
 function log(msg) {
   console.log(`[verify-published-packages] ${msg}`);
@@ -131,6 +137,54 @@ function findPublishProtocolDependencies(manifest) {
   return dependenciesWithPublishProtocols;
 }
 
+async function checkPackage(registry, name, version) {
+  let manifest;
+  try {
+    manifest = await fetchPublishedManifest(registry, name, version);
+  } catch (e) {
+    return { status: 'broken', issues: [e.message] };
+  }
+
+  if (!manifest) {
+    return { status: 'missing', issues: [] };
+  }
+
+  const issues = findPublishProtocolDependencies(manifest);
+  return issues.length > 0 ? { status: 'broken', issues } : { status: 'ok', issues: [] };
+}
+
+/**
+ * Re-check packages the registry has not caught up on yet, until they appear or
+ * the settle window expires. Only absent versions are retried: an unresolved
+ * specifier is a fact about the published manifest and will never fix itself.
+ */
+async function waitForPropagation(registry, pending) {
+  const deadline = Date.now() + PROPAGATION_SETTLE_MS;
+  let remaining = pending;
+  const broken = [];
+
+  while (remaining.length > 0 && Date.now() < deadline) {
+    const waitSeconds = Math.round(PROPAGATION_POLL_MS / 1000);
+    log(`  ${remaining.length} not visible yet, re-checking in ${waitSeconds}s...`);
+    await delay(PROPAGATION_POLL_MS);
+
+    const stillMissing = [];
+    for (const pkg of remaining) {
+      const { status, issues } = await checkPackage(registry, pkg.name, pkg.version);
+      if (status === 'ok') {
+        log(`  ${pkg.name}@${pkg.version} OK (appeared after propagation)`);
+      } else if (status === 'broken') {
+        broken.push({ ...pkg, issues });
+      } else {
+        stillMissing.push(pkg);
+      }
+    }
+    remaining = stillMissing;
+  }
+
+  return { missing: remaining, broken };
+}
+
 async function main() {
   const { registry, allowMissing } = parseArgs(process.argv.slice(2));
   const packages = getPublishablePackages();
@@ -138,35 +192,32 @@ async function main() {
   log(`Verifying ${packages.length} publishable packages against ${registry}`);
 
   const broken = [];
-  const missing = [];
+  let missing = [];
 
   for (const { name, version } of packages) {
-    let manifest;
-    try {
-      manifest = await fetchPublishedManifest(registry, name, version);
-    } catch (e) {
-      error(e.message);
-      broken.push({ name, version, issues: [e.message] });
-      continue;
-    }
+    const { status, issues } = await checkPackage(registry, name, version);
 
-    if (!manifest) {
-      missing.push({ name, version });
-      log(`  ${name}@${version} is not on the registry`);
-      continue;
-    }
-
-    const issues = findPublishProtocolDependencies(manifest);
-    if (issues.length > 0) {
+    if (status === 'broken') {
       broken.push({ name, version, issues });
       error(`${name}@${version} published with unresolved pnpm protocols:`);
       for (const issue of issues) {
         error(`  ${issue}`);
       }
-      continue;
+    } else if (status === 'missing') {
+      missing.push({ name, version });
+      log(`  ${name}@${version} is not on the registry yet`);
+    } else {
+      log(`  ${name}@${version} OK`);
     }
+  }
 
-    log(`  ${name}@${version} OK`);
+  // Absent versions may simply not have propagated yet, so give the registry
+  // time to catch up before calling the release broken.
+  if (missing.length > 0 && !allowMissing) {
+    log(`\nWaiting up to ${PROPAGATION_SETTLE_MS / 60000} minutes for the registry to catch up`);
+    const settled = await waitForPropagation(registry, missing);
+    missing = settled.missing;
+    broken.push(...settled.broken);
   }
 
   log('\n=== Summary ===');


### PR DESCRIPTION
Follow-up to #7980. Both problems surfaced while publishing the 3.x.2 release that fixed #7979.

## 1. The tag trigger does not fire for a real release

`publish.yml` triggers on `push: tags: 'decap-*@*'`. GitHub creates **no workflow run at all** when a single push carries many tags, and a release pushes one tag per package — 41 of them.

Publishing 3.x.2 required deleting a tag and re-pushing it on its own to get a run to start:

```sh
git push origin :refs/tags/decap-cms-core@3.19.0
git push origin refs/tags/decap-cms-core@3.19.0
```

That is not a workflow anyone should have to remember, and it is a bad thing to be improvising during an incident — reaching for a local `lerna publish` at that moment is exactly what caused #7979 in the first place.

Adds `workflow_dispatch` so a release can be published from the Actions tab against the `chore(release): publish` commit, and documents that the tag trigger is not to be relied on. `pnpm publish -r` skips versions already on the registry, so the manual trigger is also a safe way to resume a partially published release.

## 2. The verification gate failed a good release

Run [34447050700](https://github.com/decaporg/decap-cms/actions/runs/34447050700) is marked failed. The publish was fine — 41 `✅ Published package` lines, zero errors, one attempt. The `verify:published` step failed it.

The gate was wrong. npm accepts a publish before the version becomes readable, and the lag is per package:

| package | accepted | visible |
| --- | --- | --- |
| `decap-cms-widget-image@3.4.2` | 06:59:57 | 07:04:07 |

Running seconds after the publish, the gate reported 5 packages as missing. All 5 were live shortly after, and the release verifies clean:

```
verified: 41   missing: 0   broken: 0
```

A gate that reports a good release as broken is a gate people learn to ignore, which defeats the point of adding it. Absent versions now get a 10 minute settle window, re-polling only the ones not yet visible.

**Unresolved `catalog:` specifiers still fail immediately.** That is a property of the published manifest and will never fix itself, so retrying it would only delay — or hide — a real break. Only absence is retried.

Verified both paths: instant on the happy path (41/41 clean, no delay), and it settles then fails cleanly when a version genuinely never lands.

## Release status, for reference

3.x.2 is out and healthy. The original breakage is resolved, including retroactively for older releases whose caret ranges had rolled forward onto the broken versions:

```
decap-cms@3.16.2      -> INSTALLS OK
decap-server@3.11.2   -> INSTALLS OK
decap-cms@3.16.0      -> INSTALLS OK   <- was broken
decap-cms@3.14.0      -> INSTALLS OK   <- was broken
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
