### PR TITLE
feat: spike design tokens / branding.theme overrides

### DIFF
--- a/packages/decap-cms-core/index.d.ts
+++ b/packages/decap-cms-core/index.d.ts
@@ -437,6 +437,23 @@ declare module 'decap-cms-core' {
       src: string;
       show_in_header?: boolean;
     };
+    branding?: {
+      theme?: {
+        primary?: string;
+        background?: string;
+        foreground?: string;
+        text?: string;
+        textLead?: string;
+        activeBackground?: string;
+        borderRadius?: string;
+        fontFamily?: string;
+        status?: {
+          draft?: string;
+          in_review?: string;
+          ready?: string;
+        };
+      };
+    };
     show_preview_links?: boolean;
     media_folder?: string;
     public_folder?: string;

--- a/packages/decap-cms-core/src/bootstrap.js
+++ b/packages/decap-cms-core/src/bootstrap.js
@@ -2,7 +2,7 @@ import './lib/polyfill';
 import { createRoot } from 'react-dom/client';
 import { Provider, connect } from 'react-redux';
 import { Route, Router } from 'react-router-dom';
-import { GlobalStyles } from 'decap-cms-ui-default';
+import { GlobalStyles, ThemeStyles } from 'decap-cms-ui-default';
 import { I18n } from 'react-polyglot';
 
 import { store } from './redux';
@@ -22,6 +22,7 @@ const ROOT_ID = 'nc-root';
 function TranslatedApp({ locale, config }) {
   return (
     <I18n locale={locale} messages={getPhrases(locale)}>
+      <ThemeStyles theme={config?.branding?.theme} />
       <ErrorBoundary showBackup config={config}>
         <Router history={history}>
           <Route component={App} />

--- a/packages/decap-cms-core/src/constants/__tests__/configSchema.spec.js
+++ b/packages/decap-cms-core/src/constants/__tests__/configSchema.spec.js
@@ -667,5 +667,43 @@ describe('config', () => {
         }).not.toThrow();
       });
     });
+
+    describe('branding.theme', () => {
+      it('should allow branding.theme overrides', () => {
+        expect(() => {
+          validateConfig(
+            merge({}, validConfig, {
+              branding: {
+                theme: {
+                  primary: '#112f4e',
+                  background: '#f5f6f8',
+                  text: '#313d3e',
+                  status: {
+                    draft: '#70399f',
+                    in_review: '#754e00',
+                    ready: '#005614',
+                  },
+                },
+              },
+            }),
+          );
+        }).not.toThrow();
+      });
+
+      it('should reject unknown branding.theme keys', () => {
+        expect(() => {
+          validateConfig(
+            merge({}, validConfig, {
+              branding: {
+                theme: {
+                  primary: '#112f4e',
+                  neonGlow: '#ff00ff',
+                },
+              },
+            }),
+          );
+        }).toThrowError(`'branding.theme' must NOT have additional properties`);
+      });
+    });
   });
 });

--- a/packages/decap-cms-core/src/constants/configSchema.js
+++ b/packages/decap-cms-core/src/constants/configSchema.js
@@ -202,6 +202,35 @@ function getConfigSchema() {
         },
         required: ['src'],
       },
+      branding: {
+        type: 'object',
+        properties: {
+          theme: {
+            type: 'object',
+            properties: {
+              primary: { type: 'string', examples: ['#112f4e'] },
+              background: { type: 'string', examples: ['#f5f6f8'] },
+              foreground: { type: 'string', examples: ['#ffffff'] },
+              text: { type: 'string', examples: ['#798291'] },
+              textLead: { type: 'string', examples: ['#313d3e'] },
+              activeBackground: { type: 'string', examples: ['#e8f5fe'] },
+              borderRadius: { type: 'string', examples: ['5px'] },
+              fontFamily: { type: 'string', examples: ['system-ui, sans-serif'] },
+              status: {
+                type: 'object',
+                properties: {
+                  draft: { type: 'string', examples: ['#70399f'] },
+                  in_review: { type: 'string', examples: ['#754e00'] },
+                  ready: { type: 'string', examples: ['#005614'] },
+                },
+                additionalProperties: false,
+              },
+            },
+            additionalProperties: false,
+          },
+        },
+        additionalProperties: false,
+      },
       show_preview_links: { type: 'boolean' },
       media_folder: { type: 'string', examples: ['assets/uploads'] },
       public_folder: { type: 'string', examples: ['/uploads'] },

--- a/packages/decap-cms-core/src/types/redux.ts
+++ b/packages/decap-cms-core/src/types/redux.ts
@@ -474,6 +474,23 @@ export interface CmsConfig {
     src: string;
     show_in_header?: boolean;
   };
+  branding?: {
+    theme?: {
+      primary?: string;
+      background?: string;
+      foreground?: string;
+      text?: string;
+      textLead?: string;
+      activeBackground?: string;
+      borderRadius?: string;
+      fontFamily?: string;
+      status?: {
+        draft?: string;
+        in_review?: string;
+        ready?: string;
+      };
+    };
+  };
   show_preview_links?: boolean;
   media_folder?: string;
   public_folder?: string;

--- a/packages/decap-cms-ui-default/src/ThemeStyles.js
+++ b/packages/decap-cms-ui-default/src/ThemeStyles.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css, Global } from '@emotion/react';
+
+import { buildThemeCssVars } from './themeTokens';
+
+/**
+ * Injects CSS custom properties for the active theme.
+ * Renders after GlobalStyles so config overrides win over defaults.
+ */
+function ThemeStyles({ theme }) {
+  const vars = buildThemeCssVars(theme);
+
+  return (
+    <Global
+      styles={css`
+        :root {
+          ${vars}
+        }
+      `}
+    />
+  );
+}
+
+ThemeStyles.propTypes = {
+  theme: PropTypes.object,
+};
+
+export default ThemeStyles;

--- a/packages/decap-cms-ui-default/src/__tests__/themeTokens.spec.js
+++ b/packages/decap-cms-ui-default/src/__tests__/themeTokens.spec.js
@@ -1,0 +1,60 @@
+import {
+  DEFAULT_THEME_VALUES,
+  THEME_TOKEN_MAP,
+  buildThemeCssVars,
+  normalizeThemeConfig,
+  themeVar,
+} from '../themeTokens';
+
+describe('themeTokens', () => {
+  describe('normalizeThemeConfig', () => {
+    it('flattens nested status keys', () => {
+      expect(
+        normalizeThemeConfig({
+          primary: '#112f4e',
+          status: {
+            draft: '#111111',
+            in_review: '#222222',
+            ready: '#333333',
+          },
+        }),
+      ).toEqual({
+        primary: '#112f4e',
+        statusDraft: '#111111',
+        statusInReview: '#222222',
+        statusReady: '#333333',
+      });
+    });
+
+    it('returns empty object for invalid input', () => {
+      expect(normalizeThemeConfig(null)).toEqual({});
+      expect(normalizeThemeConfig(undefined)).toEqual({});
+    });
+  });
+
+  describe('buildThemeCssVars', () => {
+    it('includes default token declarations', () => {
+      const css = buildThemeCssVars();
+      expect(css).toContain(`${THEME_TOKEN_MAP.primary}: ${DEFAULT_THEME_VALUES.primary};`);
+      expect(css).toContain(`${THEME_TOKEN_MAP.background}: ${DEFAULT_THEME_VALUES.background};`);
+    });
+
+    it('applies overrides from branding.theme shape', () => {
+      const css = buildThemeCssVars({
+        primary: '#112f4e',
+        status: { draft: '#abcdef' },
+      });
+      expect(css).toContain(`${THEME_TOKEN_MAP.primary}: #112f4e;`);
+      expect(css).toContain(`${THEME_TOKEN_MAP.statusDraft}: #abcdef;`);
+      expect(css).toContain(`${THEME_TOKEN_MAP.text}: ${DEFAULT_THEME_VALUES.text};`);
+    });
+  });
+
+  describe('themeVar', () => {
+    it('returns a CSS custom property with fallback', () => {
+      expect(themeVar('primary', '#3a69c7')).toBe(
+        `var(${THEME_TOKEN_MAP.primary}, #3a69c7)`,
+      );
+    });
+  });
+});

--- a/packages/decap-cms-ui-default/src/index.js
+++ b/packages/decap-cms-ui-default/src/index.js
@@ -30,6 +30,14 @@ import {
   reactSelectStyles,
   GlobalStyles,
 } from './styles';
+import ThemeStyles from './ThemeStyles';
+import {
+  THEME_TOKEN_MAP,
+  DEFAULT_THEME_VALUES,
+  normalizeThemeConfig,
+  buildThemeCssVars,
+  themeVar,
+} from './themeTokens';
 
 export const DecapCmsUiDefault = {
   Dropdown,
@@ -63,6 +71,7 @@ export const DecapCmsUiDefault = {
   zIndex,
   reactSelectStyles,
   GlobalStyles,
+  ThemeStyles,
   renderPageLogo,
 };
 export {
@@ -97,6 +106,12 @@ export {
   zIndex,
   reactSelectStyles,
   GlobalStyles,
+  ThemeStyles,
   GoBackButton,
   renderPageLogo,
+  THEME_TOKEN_MAP,
+  DEFAULT_THEME_VALUES,
+  normalizeThemeConfig,
+  buildThemeCssVars,
+  themeVar,
 };

--- a/packages/decap-cms-ui-default/src/styles.js
+++ b/packages/decap-cms-ui-default/src/styles.js
@@ -1,10 +1,14 @@
 import { css, Global } from '@emotion/react';
 
+import { buildThemeCssVars, themeVar } from './themeTokens';
+
 /**
  * Font Stacks
  */
 const fonts = {
-  primary: `
+  primary: themeVar(
+    'fontFamily',
+    `
     system-ui,
     -apple-system,
     BlinkMacSystemFont,
@@ -17,6 +21,7 @@ const fonts = {
     "Segoe UI Emoji",
     "Segoe UI Symbol"
   `,
+  ),
   mono: `
     'SFMono-Regular',
     Consolas,
@@ -51,29 +56,33 @@ const colorsRaw = {
   tealLight: '#ddf5f9',
 };
 
+/**
+ * Semantic colors use CSS custom properties so `branding.theme` can override
+ * them without rewriting Emotion styles. Fallbacks preserve current defaults.
+ */
 const colors = {
-  statusDraftText: colorsRaw.purple,
+  statusDraftText: themeVar('statusDraft', colorsRaw.purple),
   statusDraftBackground: colorsRaw.purpleLight,
-  statusReviewText: colorsRaw.brown,
+  statusReviewText: themeVar('statusInReview', colorsRaw.brown),
   statusReviewBackground: colorsRaw.yellow,
-  statusReadyText: colorsRaw.green,
+  statusReadyText: themeVar('statusReady', colorsRaw.green),
   statusReadyBackground: colorsRaw.greenLight,
-  text: colorsRaw.gray,
+  text: themeVar('text', colorsRaw.gray),
   textLight: colorsRaw.white,
-  textLead: colorsRaw.grayDark,
-  background: colorsRaw.grayLight,
-  foreground: colorsRaw.white,
-  active: colorsRaw.blue,
-  activeBackground: colorsRaw.blueLight,
+  textLead: themeVar('textLead', colorsRaw.grayDark),
+  background: themeVar('background', colorsRaw.grayLight),
+  foreground: themeVar('foreground', colorsRaw.white),
+  active: themeVar('primary', colorsRaw.blue),
+  activeBackground: themeVar('activeBackground', colorsRaw.blueLight),
   inactive: colorsRaw.gray,
   button: colorsRaw.grayDark,
   buttonText: colorsRaw.white,
   inputBackground: colorsRaw.white,
-  infoText: colorsRaw.blue,
-  infoBackground: colorsRaw.blueLight,
-  successText: colorsRaw.green,
+  infoText: themeVar('primary', colorsRaw.blue),
+  infoBackground: themeVar('activeBackground', colorsRaw.blueLight),
+  successText: themeVar('statusReady', colorsRaw.green),
   successBackground: colorsRaw.greenLight,
-  warnText: colorsRaw.brown,
+  warnText: themeVar('statusInReview', colorsRaw.brown),
   warnBackground: colorsRaw.yellow,
   errorText: colorsRaw.red,
   errorBackground: colorsRaw.redLight,
@@ -81,14 +90,14 @@ const colors = {
   controlLabel: '#5D626F',
   checkerboardLight: '#f2f2f2',
   checkerboardDark: '#e6e6e6',
-  mediaDraftText: colorsRaw.purple,
+  mediaDraftText: themeVar('statusDraft', colorsRaw.purple),
   mediaDraftBackground: colorsRaw.purpleLight,
 };
 
 const lengths = {
   topBarHeight: '56px',
   inputPadding: '16px 20px',
-  borderRadius: '5px',
+  borderRadius: themeVar('borderRadius', '5px'),
   richTextEditorMinHeight: '300px',
   borderWidth: '2px',
   topCardWidth: '682px',
@@ -439,6 +448,10 @@ function GlobalStyles() {
   return (
     <Global
       styles={css`
+        :root {
+          ${buildThemeCssVars()}
+        }
+
         *,
         *:before,
         *:after {

--- a/packages/decap-cms-ui-default/src/themeTokens.js
+++ b/packages/decap-cms-ui-default/src/themeTokens.js
@@ -1,0 +1,84 @@
+/**
+ * Semantic UI theme tokens for Decap CMS.
+ *
+ * Spike for https://github.com/decaporg/decap-cms/issues/1727
+ * Defaults match the existing styles.js palette; overrides come from
+ * `branding.theme` in config.yml (or CMS.init config).
+ */
+
+export const THEME_TOKEN_PREFIX = '--decap';
+
+/**
+ * Public config keys → CSS custom property names.
+ * Keep this list small for the MVP; expand once maintainers align.
+ */
+export const THEME_TOKEN_MAP = {
+  primary: `${THEME_TOKEN_PREFIX}-color-primary`,
+  background: `${THEME_TOKEN_PREFIX}-color-background`,
+  foreground: `${THEME_TOKEN_PREFIX}-color-foreground`,
+  text: `${THEME_TOKEN_PREFIX}-color-text`,
+  textLead: `${THEME_TOKEN_PREFIX}-color-text-lead`,
+  activeBackground: `${THEME_TOKEN_PREFIX}-color-active-background`,
+  borderRadius: `${THEME_TOKEN_PREFIX}-radius`,
+  fontFamily: `${THEME_TOKEN_PREFIX}-font-family`,
+  statusDraft: `${THEME_TOKEN_PREFIX}-color-status-draft`,
+  statusInReview: `${THEME_TOKEN_PREFIX}-color-status-in-review`,
+  statusReady: `${THEME_TOKEN_PREFIX}-color-status-ready`,
+};
+
+export const DEFAULT_THEME_VALUES = {
+  primary: '#3a69c7',
+  background: '#eff0f4',
+  foreground: '#fff',
+  text: '#798291',
+  textLead: '#313d3e',
+  activeBackground: '#e8f5fe',
+  borderRadius: '5px',
+  fontFamily: `system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"`,
+  statusDraft: '#70399f',
+  statusInReview: '#754e00',
+  statusReady: '#005614',
+};
+
+/**
+ * Flatten `branding.theme` config (including nested `status`) into token keys.
+ */
+export function normalizeThemeConfig(themeConfig = {}) {
+  if (!themeConfig || typeof themeConfig !== 'object') {
+    return {};
+  }
+
+  const { status, ...rest } = themeConfig;
+  const normalized = { ...rest };
+
+  if (status && typeof status === 'object') {
+    if (status.draft) normalized.statusDraft = status.draft;
+    if (status.in_review) normalized.statusInReview = status.in_review;
+    if (status.ready) normalized.statusReady = status.ready;
+  }
+
+  return normalized;
+}
+
+/**
+ * Build a CSS declaration block for `:root` from defaults + optional overrides.
+ */
+export function buildThemeCssVars(themeConfig) {
+  const overrides = normalizeThemeConfig(themeConfig);
+  const values = { ...DEFAULT_THEME_VALUES, ...overrides };
+
+  return Object.entries(THEME_TOKEN_MAP)
+    .map(([key, cssVar]) => `${cssVar}: ${values[key]};`)
+    .join('\n');
+}
+
+/**
+ * Helper used by styles.js so semantic colors read tokens with hex fallbacks.
+ */
+export function themeVar(tokenKey, fallback) {
+  const cssVar = THEME_TOKEN_MAP[tokenKey];
+  if (!cssVar) {
+    return fallback;
+  }
+  return `var(${cssVar}, ${fallback})`;
+}


### PR DESCRIPTION
## Summary
- **Draft spike** for incremental UI theming discussed in #1727 / #3559
- Maps semantic colors (and a few related tokens) to CSS custom properties with current palette as fallbacks
- Adds optional `branding.theme` config overrides that re-inject `:root` vars at runtime
- Defaults are unchanged when `branding.theme` is omitted

This is intentionally small and incomplete — meant to validate direction with maintainers before expanding coverage / dark mode / next-ui work.

### Example
```yml
branding:
  theme:
    primary: '#112f4e'
    background: '#f5f6f8'
    text: '#798291'
    textLead: '#313d3e'
    status:
      draft: '#70399f'
      in_review: '#754e00'
      ready: '#005614'
```

### Notes / non-goals for this draft
- Not all hard-coded hex values across widgets are tokenized yet
- No dark mode yet
- No `CMS.registerTheme()` API yet
- Not a `next-ui` port

## Test plan
- [x] Unit tests for token helpers (`themeTokens.spec.js`)
- [x] Config schema accepts `branding.theme` and rejects unknown keys
- [ ] Manual: run CMS with `branding.theme.primary` set and confirm header/active accents + body background pick up overrides
- [ ] Manual: omit `branding.theme` and confirm UI looks identical to current `main`

Refs: #1727 #3559

Made with [Cursor](https://cursor.com)