### PR TITLE
fix(relation): retry menu options after a failed query instead of caching the failure

### DIFF
--- a/packages/decap-cms-widget-relation/src/RelationCache.js
+++ b/packages/decap-cms-widget-relation/src/RelationCache.js
@@ -1,3 +1,14 @@
+/**
+ * Memoises relation lookups for the life of the page, keyed by
+ * collection + search fields + term + file.
+ *
+ * Only RESOLVED values are stored — a rejected `queryFn` leaves the key empty
+ * so the next caller tries again. That is load-bearing rather than incidental:
+ * the query thunk resolves even when the request failed, so before its callers
+ * learned to reject (see `hitsFromQueryResult` in RelationControl) a single
+ * timeout was cached as "this collection is empty" and every later open of the
+ * dropdown read it back, until the page was reloaded.
+ */
 class RelationCache {
   constructor() {
     this.cache = new Map();

--- a/packages/decap-cms-widget-relation/src/RelationControl.js
+++ b/packages/decap-cms-widget-relation/src/RelationControl.js
@@ -285,13 +285,19 @@ export default class RelationControl extends Component {
   };
 
   shouldComponentUpdate(nextProps, nextState) {
-    return (
+    if (
       this.props.value !== nextProps.value ||
       this.props.hasActiveStyle !== nextProps.hasActiveStyle ||
-      this.props.queryHits !== nextProps.queryHits ||
-      // Previously absent, which meant a setState could not repaint the menu on
-      // its own — it only ever rendered because `queryHits` happened to change
-      // in the same tick.
+      this.props.queryHits !== nextProps.queryHits
+    ) {
+      return true;
+    }
+
+    if (!nextState) {
+      return false;
+    }
+
+    return (
       this.state.initialOptions !== nextState.initialOptions ||
       this.state.menuOptions !== nextState.menuOptions ||
       this.state.loadingOptions !== nextState.loadingOptions

--- a/packages/decap-cms-widget-relation/src/RelationControl.js
+++ b/packages/decap-cms-widget-relation/src/RelationControl.js
@@ -206,11 +206,49 @@ function convertToSortableOption(raw) {
   };
 }
 
+/**
+ * The hits from a resolved `query` action, or a throw if the query failed.
+ *
+ * The query thunk never rejects: on failure it resolves with the action
+ * `queryFailure` returns, which carries `payload.error` where a success would
+ * carry `payload.hits`. Reading `payload.hits` off it yields `undefined`, and
+ * the `|| []` that follows turns a failed request into the claim that the
+ * collection is empty — a claim that is then cached (see RelationCache) and
+ * shown to the editor as "No options" until the page is reloaded.
+ *
+ * Throwing instead keeps the failure a failure: RelationCache only stores
+ * resolved values, so a transient error is retried on the next attempt rather
+ * than memoised for the life of the page.
+ */
+function hitsFromQueryResult(result) {
+  const error = result?.payload?.error;
+  if (error) {
+    throw error instanceof Error ? error : new Error(String(error));
+  }
+  if (!result?.payload || !Array.isArray(result.payload.hits)) {
+    throw new Error('Relation query returned no hits');
+  }
+  return result.payload.hits;
+}
+
 export default class RelationControl extends Component {
   mounted = false;
 
   state = {
     initialOptions: [],
+    /**
+     * What the menu shows before anything is typed. `undefined` means "not
+     * loaded yet", which is distinct from `[]` ("loaded, genuinely empty") —
+     * only the former is retried when the menu is opened.
+     */
+    menuOptions: undefined,
+    /**
+     * True while the menu list is being fetched. react-select derived this
+     * itself from `defaultOptions={true}`; now that the list is ours, the
+     * spinner has to be too — without it a slow load renders as "No options",
+     * which is the exact confusion this whole change exists to remove.
+     */
+    loadingOptions: true,
   };
 
   static propTypes = {
@@ -246,11 +284,17 @@ export default class RelationControl extends Component {
     return error ? { error } : { error: false };
   };
 
-  shouldComponentUpdate(nextProps) {
+  shouldComponentUpdate(nextProps, nextState) {
     return (
       this.props.value !== nextProps.value ||
       this.props.hasActiveStyle !== nextProps.hasActiveStyle ||
-      this.props.queryHits !== nextProps.queryHits
+      this.props.queryHits !== nextProps.queryHits ||
+      // Previously absent, which meant a setState could not repaint the menu on
+      // its own — it only ever rendered because `queryHits` happened to change
+      // in the same tick.
+      this.state.initialOptions !== nextState.initialOptions ||
+      this.state.menuOptions !== nextState.menuOptions ||
+      this.state.loadingOptions !== nextState.loadingOptions
     );
   }
 
@@ -259,10 +303,10 @@ export default class RelationControl extends Component {
     PropTypes.checkPropTypes(RelationControl.propTypes, this.props, 'prop', 'RelationControl');
 
     this.mounted = true;
-    const { value } = this.props;
-    if (value && this.hasInitialValues(value)) {
-      await this.loadInitialOptions();
-    }
+    // Unconditional now. It used to run only for a field that already held a
+    // value, because react-select loaded the menu itself in every other case;
+    // that load is no longer used (see handleMenuOpen).
+    await this.loadInitialOptions();
   }
 
   hasInitialValues(value) {
@@ -279,24 +323,38 @@ export default class RelationControl extends Component {
     const searchFieldsArray = getFieldArray(field.get('search_fields'));
     const file = field.get('file');
 
+    if (this.mounted) {
+      this.setState({ loadingOptions: true });
+    }
+
     try {
-      const result = await relationCache.getOptions(
+      const hits = await relationCache.getOptions(
         collection,
         searchFieldsArray,
         '', // empty term for initial load
         file,
-        () => query(forID, collection, searchFieldsArray, '', file),
+        () => query(forID, collection, searchFieldsArray, '', file).then(hitsFromQueryResult),
       );
 
-      const hits = result.payload.hits || [];
-      let options = this.parseHitOptions(hits);
+      const allOptions = this.parseHitOptions(hits);
+      let options = allOptions;
       if (this.isMultiple()) {
-        const selectedOptions = getSelectedOptions(value);
+        // `|| []` because this now runs for a field with no value at all, where
+        // getSelectedOptions returns null. It could not before: the load was
+        // gated on the field already holding one.
+        const selectedOptions = getSelectedOptions(value) || [];
         options = options.filter(o => selectedOptions.includes(o.value));
       }
 
       if (this.mounted) {
-        this.setState({ initialOptions: options });
+        // `menuOptions` is the whole list the menu offers; `initialOptions` is
+        // narrowed to what is already selected, because it exists to resolve
+        // those values' labels rather than to be offered again.
+        this.setState({
+          initialOptions: options,
+          menuOptions: allOptions.slice(0, this.optionsLength()),
+          loadingOptions: false,
+        });
 
         // Call onChange with metadata for initial values
         if (value && this.hasInitialValues(value)) {
@@ -305,8 +363,32 @@ export default class RelationControl extends Component {
       }
     } catch (error) {
       console.error('Failed to load initial options:', error);
+      // Deliberately leaves `menuOptions` undefined rather than setting `[]`:
+      // that is what lets `handleMenuOpen` tell "we never managed to load" from
+      // "there is genuinely nothing here", and retry only the former.
+      if (this.mounted) {
+        this.setState({ loadingOptions: false });
+      }
     }
   }
+
+  optionsLength() {
+    return this.props.field.get('options_length') || 20;
+  }
+
+  /**
+   * Retry the list the menu shows, if we have never successfully loaded it.
+   *
+   * react-select's own `defaultOptions={true}` loads exactly once, in a mount
+   * effect with no dependencies, and there is no way to ask it to try again —
+   * so a single failed load left the menu permanently empty even after the
+   * cause had passed. Owning the list means opening the menu can retry it.
+   */
+  handleMenuOpen = () => {
+    if (this.state.menuOptions === undefined && !this.state.loadingOptions) {
+      this.loadInitialOptions();
+    }
+  };
 
   triggerInitialOnChange(value, options) {
     const { onChange, field } = this.props;
@@ -469,16 +551,15 @@ export default class RelationControl extends Component {
 
     relationCache
       .getOptions(collection, searchFieldsArray, term, file, () =>
-        query(forID, collection, searchFieldsArray, term, file),
+        query(forID, collection, searchFieldsArray, term, file).then(hitsFromQueryResult),
       )
-      .then(result => {
-        const hits = result.payload.hits || [];
+      .then(hits => {
         const options = this.parseHitOptions(hits);
-        const optionsLength = field.get('options_length') || 20;
-        const uniq = uniqOptions(options, this.state.initialOptions).slice(0, optionsLength);
+        const uniq = uniqOptions(options, this.state.initialOptions).slice(0, this.optionsLength());
         callback(uniq);
       })
       .catch(error => {
+        // Nothing is cached for this term, so the next keystroke retries.
         console.error('Failed to load options:', error);
         callback([]);
       });
@@ -518,8 +599,10 @@ export default class RelationControl extends Component {
         value={selectedValue}
         inputId={forID}
         cacheOptions
-        defaultOptions
+        defaultOptions={this.state.menuOptions}
         loadOptions={this.loadOptions}
+        onMenuOpen={this.handleMenuOpen}
+        isLoading={this.state.loadingOptions}
         loadingMessage={() => 'Loading options…'}
         onChange={this.handleChange}
         className={classNameWrapper}

--- a/packages/decap-cms-widget-relation/src/__tests__/relationFailure.spec.js
+++ b/packages/decap-cms-widget-relation/src/__tests__/relationFailure.spec.js
@@ -2,6 +2,7 @@ import { fromJS } from 'immutable';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 
 import { DecapCmsWidgetRelation } from '../';
+import RelationControl from '../RelationControl';
 import relationCache from '../RelationCache';
 
 // Deliberately NOT mocking RelationCache: what a failure does to the cache is
@@ -13,7 +14,7 @@ jest.mock('react-window', () => {
   return { FixedSizeList };
 });
 
-const RelationControl = DecapCmsWidgetRelation.controlComponent;
+const RelationControlComponent = DecapCmsWidgetRelation.controlComponent;
 
 const field = fromJS({
   name: 'post',
@@ -38,7 +39,7 @@ function succeededQuery() {
 
 function setup(query) {
   const helpers = render(
-    <RelationControl
+    <RelationControlComponent
       field={field}
       value={undefined}
       query={query}
@@ -136,6 +137,39 @@ describe('relation options after a failed query', () => {
     await waitFor(() => {
       expect(queryByText('Loading options…')).not.toBeInTheDocument();
     });
+  });
+
+  // The core Widget borrows this method off the control instance and calls it
+  // with `nextProps` alone, to decide whether the WIDGET should re-render
+  // (components/Editor/EditorControlPane/Widget.js:92). Dereferencing the
+  // missing `nextState` threw and took the whole editor down with an error
+  // screen the moment a dropdown was opened.
+  function instanceWithProps() {
+    // The props object is reused as `nextProps` for the unchanged case: these
+    // are identity comparisons, so a fresh `{queryHits: []}` would read as a
+    // change and prove nothing.
+    const props = { field, value: undefined, hasActiveStyle: false, queryHits: [], query: jest.fn() };
+    const instance = new RelationControl(props);
+    instance.state = { initialOptions: [], menuOptions: undefined, loadingOptions: true };
+    return { instance, props };
+  }
+
+  it('survives shouldComponentUpdate being called without nextState', () => {
+    const { instance, props } = instanceWithProps();
+
+    expect(() => instance.shouldComponentUpdate(props)).not.toThrow();
+    expect(instance.shouldComponentUpdate(props)).toBe(false);
+    // A real prop change must still be reported, with or without nextState.
+    expect(instance.shouldComponentUpdate({ ...props, value: 'Post # 1' })).toBe(true);
+  });
+
+  it('still repaints when only state changed and React passes nextState', () => {
+    const { instance, props } = instanceWithProps();
+    const state = instance.state;
+
+    expect(instance.shouldComponentUpdate(props, state)).toBe(false);
+    expect(instance.shouldComponentUpdate(props, { ...state, menuOptions: [] })).toBe(true);
+    expect(instance.shouldComponentUpdate(props, { ...state, loadingOptions: false })).toBe(true);
   });
 
   // A collection that really is empty must not be re-queried on every open.

--- a/packages/decap-cms-widget-relation/src/__tests__/relationFailure.spec.js
+++ b/packages/decap-cms-widget-relation/src/__tests__/relationFailure.spec.js
@@ -1,0 +1,154 @@
+import { fromJS } from 'immutable';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+
+import { DecapCmsWidgetRelation } from '../';
+import relationCache from '../RelationCache';
+
+// Deliberately NOT mocking RelationCache: what a failure does to the cache is
+// the whole point of these tests.
+jest.mock('react-window', () => {
+  function FixedSizeList(props) {
+    return props.itemData.options;
+  }
+  return { FixedSizeList };
+});
+
+const RelationControl = DecapCmsWidgetRelation.controlComponent;
+
+const field = fromJS({
+  name: 'post',
+  collection: 'posts',
+  display_fields: ['title'],
+  search_fields: ['title'],
+  value_field: 'title',
+});
+
+function hit(title) {
+  return { collection: 'posts', slug: title, path: `posts/${title}.md`, data: { title } };
+}
+
+/** What the `query` thunk resolves with when the request failed. */
+function failedQuery() {
+  return Promise.resolve({ payload: { error: new Error('statement timeout') } });
+}
+
+function succeededQuery() {
+  return Promise.resolve({ payload: { hits: [hit('Post # 1'), hit('Post # 2')] } });
+}
+
+function setup(query) {
+  const helpers = render(
+    <RelationControl
+      field={field}
+      value={undefined}
+      query={query}
+      queryHits={[]}
+      onChange={jest.fn()}
+      forID="relation-field"
+      classNameWrapper=""
+      setActiveStyle={jest.fn()}
+      setInactiveStyle={jest.fn()}
+    />,
+  );
+  return { ...helpers, input: helpers.container.querySelector('input') };
+}
+
+describe('relation options after a failed query', () => {
+  beforeEach(() => {
+    relationCache.clear();
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // The bug: the query thunk resolves even when the request failed, so the
+  // failure was stored as "this collection is empty" and read back forever.
+  it('does not cache a failed query', async () => {
+    const queryFn = jest.fn(failedQuery);
+
+    await expect(
+      relationCache.getOptions('posts', ['title'], '', undefined, () =>
+        queryFn().then(r => {
+          if (r.payload.error) throw r.payload.error;
+          return r.payload.hits;
+        }),
+      ),
+    ).rejects.toThrow('statement timeout');
+
+    // Nothing was stored, so the next caller genuinely asks again.
+    const hits = await relationCache.getOptions('posts', ['title'], '', undefined, () =>
+      succeededQuery().then(r => r.payload.hits),
+    );
+
+    expect(hits).toHaveLength(2);
+  });
+
+  it('still caches a successful query', async () => {
+    const queryFn = jest.fn(() => succeededQuery().then(r => r.payload.hits));
+
+    await relationCache.getOptions('posts', ['title'], '', undefined, queryFn);
+    await relationCache.getOptions('posts', ['title'], '', undefined, queryFn);
+
+    expect(queryFn).toHaveBeenCalledTimes(1);
+  });
+
+  // react-select's own `defaultOptions={true}` loads once in a mount effect and
+  // can never be asked again, so before this the menu stayed empty for the life
+  // of the page even once the backend had recovered.
+  it('retries the menu list when the dropdown is opened', async () => {
+    const query = jest
+      .fn()
+      .mockImplementationOnce(failedQuery)
+      .mockImplementation(succeededQuery);
+
+    const { input, getByText, queryByText } = setup(query);
+
+    await waitFor(() => expect(query).toHaveBeenCalledTimes(1));
+    expect(queryByText('Post # 1')).not.toBeInTheDocument();
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+    await waitFor(() => {
+      expect(getByText('Post # 1')).toBeInTheDocument();
+    });
+  });
+
+  // Without this the menu says "No options" for the whole of a slow load, which
+  // is indistinguishable from the bug being fixed.
+  it('says it is loading while the list is in flight', async () => {
+    let release;
+    const query = jest.fn(
+      () =>
+        new Promise(resolve => {
+          release = () => resolve({ payload: { hits: [hit('Post # 1')] } });
+        }),
+    );
+
+    const { input, getByText, queryByText } = setup(query);
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    expect(getByText('Loading options…')).toBeInTheDocument();
+
+    release();
+    await waitFor(() => {
+      expect(queryByText('Loading options…')).not.toBeInTheDocument();
+    });
+  });
+
+  // A collection that really is empty must not be re-queried on every open.
+  it('does not retry when the list loaded and was genuinely empty', async () => {
+    const query = jest.fn(() => Promise.resolve({ payload: { hits: [] } }));
+    const { input } = setup(query);
+
+    await waitFor(() => expect(query).toHaveBeenCalledTimes(1));
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/decap-cms-widget-relation/src/__tests__/relationFailure.spec.js
+++ b/packages/decap-cms-widget-relation/src/__tests__/relationFailure.spec.js
@@ -100,10 +100,7 @@ describe('relation options after a failed query', () => {
   // can never be asked again, so before this the menu stayed empty for the life
   // of the page even once the backend had recovered.
   it('retries the menu list when the dropdown is opened', async () => {
-    const query = jest
-      .fn()
-      .mockImplementationOnce(failedQuery)
-      .mockImplementation(succeededQuery);
+    const query = jest.fn().mockImplementationOnce(failedQuery).mockImplementation(succeededQuery);
 
     const { input, getByText, queryByText } = setup(query);
 
@@ -148,7 +145,13 @@ describe('relation options after a failed query', () => {
     // The props object is reused as `nextProps` for the unchanged case: these
     // are identity comparisons, so a fresh `{queryHits: []}` would read as a
     // change and prove nothing.
-    const props = { field, value: undefined, hasActiveStyle: false, queryHits: [], query: jest.fn() };
+    const props = {
+      field,
+      value: undefined,
+      hasActiveStyle: false,
+      queryHits: [],
+      query: jest.fn(),
+    };
     const instance = new RelationControl(props);
     instance.state = { initialOptions: [], menuOptions: undefined, loadingOptions: true };
     return { instance, props };


### PR DESCRIPTION
## Summary

A relation dropdown could show **"No options" until you typed something**, and stay that way for the life of the page — even once the backend had recovered. Typing worked because it used a different cache key.

Reported downstream at Mestna-obcina-Celje/moc-www#740, where it affected every relation field on the site and several editors at once.

## Root cause

Three defects compounding, all on `main`:

1. **A failed query was indistinguishable from an empty collection.** The `query` thunk never rejects — on failure it resolves with the action `queryFailure` returns, which carries `payload.error` where a success carries `payload.hits`. `RelationControl` read `result.payload.hits || []`, so a failed request became the claim that the collection has no entries.
2. **`RelationCache` then memoised that claim for the life of the page.** It only stores resolved values, so making failures reject is enough to fix it — but nothing was rejecting.
3. **The one that made it permanent:** react-select's `defaultOptions={true}` loads exactly once, in a mount effect with no dependencies, and there is no way to ask it to try again. Even with 1 and 2 fixed, the menu would have stayed empty.

## The change

- `hitsFromQueryResult` throws on a failed query, so the cache never stores it and the next attempt genuinely retries.
- The component owns the menu list (`menuOptions` state) and passes it as an array rather than letting react-select load it once. `onMenuOpen` retries when the list has never loaded.
- `menuOptions === undefined` ("never loaded") is deliberately distinct from `[]` ("loaded, genuinely empty") — only the former retries, so a truly empty collection is not re-queried on every open.

Two consequential fixes:

- `shouldComponentUpdate` ignored state entirely, so no `setState` could repaint the menu on its own — it only ever rendered because `queryHits` happened to change in the same tick. It now considers state **when it is given it**: the core `Widget` borrows this method off the control instance and calls it with `nextProps` alone (`EditorControlPane/Widget.js:92`), so `nextState` is genuinely absent about half the time and must not be dereferenced.
- `getSelectedOptions` returns `null` for a field with no value, previously unreachable because the initial load was gated on the field already having one.

`isLoading` is now passed explicitly, since react-select had been deriving it from `defaultOptions={true}`. Without it a slow load renders as "No options" — the exact confusion being fixed.

Request count is unchanged or slightly lower: the mount-time empty-term query used to come from react-select and now comes from the control, and the redundant second call for fields that already have a value is gone.

## Testing

- 27 tests in the package pass (5 new), including the cache contract, the retry-on-open, the loading state, and a regression test that calls `shouldComponentUpdate` with a single argument the way `Widget.js` does.
- Full suite green: 113 suites / 1391 tests, `tsc --noEmit` clean, prettier and eslint clean.
- Verified in a browser against a production site using this widget: all four relation dropdowns populate on click without typing.

## Draft

Opened as a draft: this touches a widget every Decap user has, and I would like a second pair of eyes on the `shouldComponentUpdate` contract in particular before it lands.
