### PR TITLE
fix(core): preserve full entries returned by preSave handlers

### DIFF
--- a/packages/decap-cms-core/src/lib/__tests__/i18n.spec.js
+++ b/packages/decap-cms-core/src/lib/__tests__/i18n.spec.js
@@ -249,6 +249,44 @@ describe('i18n', () => {
   });
 
   describe('getI18nFiles', () => {
+    it('should serialize translated preSave entries without nesting entry metadata in content', async () => {
+      const { registerEventListener, removeEventListener, invokeEvent } = require('../registry');
+      const entry = fromJS({
+        collection: 'posts',
+        slug: 'article',
+        path: 'content/article.md',
+        data: { title: 'English' },
+        i18n: { 'pt-br': { data: { title: 'Old translation' } } },
+      });
+      function handler({ entry }) {
+        return entry.setIn(['i18n', 'pt-br', 'data', 'title'], 'Portuguese');
+      }
+      registerEventListener({ name: 'preSave', handler });
+      try {
+        const result = await invokeEvent({ name: 'preSave', data: { entry } });
+        const files = i18n.getI18nFiles(
+          fromJS({
+            i18n: {
+              structure: i18n.I18N_STRUCTURE.MULTIPLE_FOLDERS,
+              locales: ['en', 'pt-br'],
+              default_locale: 'en',
+            },
+          }),
+          'md',
+          result,
+          draft => JSON.stringify(draft.get('data').toJS()),
+          'content/article.md',
+          'article',
+        );
+        expect(files).toEqual([
+          { path: 'content/en/article.md', slug: 'article', raw: '{"title":"English"}' },
+          { path: 'content/pt-br/article.md', slug: 'article', raw: '{"title":"Portuguese"}' },
+        ]);
+      } finally {
+        removeEventListener({ name: 'preSave', handler });
+      }
+    });
+
     const locales = ['en', 'de', 'fr'];
     const default_locale = 'en';
     const args = [

--- a/packages/decap-cms-core/src/lib/__tests__/registry.spec.js
+++ b/packages/decap-cms-core/src/lib/__tests__/registry.spec.js
@@ -236,6 +236,75 @@ describe('registry', () => {
         expect(result).toEqual(dataAfterSecondHandlerExecution.entry);
       });
 
+      it('should preserve a complete entry returned by a preSave handler', async () => {
+        const { registerEventListener, invokeEvent } = require('../registry');
+        const entry = fromJS({
+          collection: 'posts',
+          slug: 'article',
+          path: 'content/en/article.md',
+          meta: { path: 'content/en/article.md' },
+          data: { title: 'English' },
+          i18n: { 'pt-br': { data: { title: 'Old translation' } } },
+        });
+        const translated = entry.setIn(['i18n', 'pt-br', 'data', 'title'], 'Portuguese');
+        registerEventListener({ name: 'preSave', handler: async () => translated });
+
+        const result = await invokeEvent({ name: 'preSave', data: { entry } });
+
+        expect(result).toBe(translated);
+        expect(result.get('data')).toEqual(fromJS({ title: 'English' }));
+        expect(result.getIn(['i18n', 'pt-br', 'data', 'title'])).toBe('Portuguese');
+      });
+
+      it('should chain data-only and full-entry handlers without losing metadata or translations', async () => {
+        const { registerEventListener, invokeEvent } = require('../registry');
+        const entry = fromJS({
+          collection: 'posts',
+          slug: 'article',
+          path: 'content/en/article.md',
+          data: { title: 'English' },
+          i18n: { 'pt-br': { data: { title: 'Old translation' } } },
+        });
+        registerEventListener({
+          name: 'preSave',
+          handler: ({ entry }) => entry.get('data').set('title', 'Updated English'),
+        });
+        registerEventListener({
+          name: 'preSave',
+          handler: ({ entry }) => entry.setIn(['i18n', 'pt-br', 'data', 'title'], 'Portuguese'),
+        });
+        registerEventListener({ name: 'preSave', handler: () => undefined });
+        registerEventListener({
+          name: 'preSave',
+          handler: ({ entry }) => entry.get('data').set('description', 'Description'),
+        });
+
+        const result = await invokeEvent({ name: 'preSave', data: { entry } });
+
+        expect(result).toEqual(
+          entry
+            .setIn(['data', 'title'], 'Updated English')
+            .setIn(['data', 'description'], 'Description')
+            .setIn(['i18n', 'pt-br', 'data', 'title'], 'Portuguese'),
+        );
+      });
+
+      it('should treat a content field named data as content rather than a full entry', async () => {
+        const { registerEventListener, invokeEvent } = require('../registry');
+        const entry = fromJS({
+          collection: 'posts',
+          slug: 'article',
+          path: 'content/article.md',
+          data: { data: { title: 'Nested content' } },
+        });
+        const content = entry.get('data').setIn(['data', 'title'], 'Updated nested content');
+        registerEventListener({ name: 'preSave', handler: () => content });
+
+        const result = await invokeEvent({ name: 'preSave', data: { entry } });
+
+        expect(result).toEqual(entry.set('data', content));
+      });
+
       it('should allow multiple events to not return a value', async () => {
         const { registerEventListener, invokeEvent } = require('../registry');
 

--- a/packages/decap-cms-core/src/lib/registry.js
+++ b/packages/decap-cms-core/src/lib/registry.js
@@ -253,7 +253,11 @@ export async function invokeEvent({ name, data }) {
   for (const { handler, options } of handlers) {
     const result = await handler(_data, options);
     if (result !== undefined) {
-      const entry = _data.entry.set('data', result);
+      // Handlers may return either field data or the complete entry (for example,
+      // to update i18n). Check entry metadata too: content can have a data field.
+      const isEntry =
+        Map.isMap(result) && ['data', 'collection', 'slug', 'path'].every(key => result.has(key));
+      const entry = isEntry ? result : _data.entry.set('data', result);
       _data = { ...data, entry };
     }
   }


### PR DESCRIPTION
**Summary**

Fixes #7966. A `preSave` handler returning `entry.setIn(['i18n', locale, 'data', 'title'], value)` is currently wrapped inside the entry's `data`. This causes internal entry metadata to be saved as default-locale content and leaves the translation unchanged.

Preserve complete entry returns directly, while continuing to wrap field-data returns. Recognize the full entry by its Immutable Map shape and the `data`, `collection`, `slug`, and `path` keys supplied by `createEntry`; checking only `data` would misclassify a legitimate content field with that name. The event still returns the complete entry, preserving the file-collection fix from #7667.

**Test plan**

- Four new tests cover full-entry returns, mixed full-entry/data-only handler chains (including an undefined return), a content field named `data`, and passing a translated entry through the actual multiple-folder i18n file generator. The output assertions verify intact English content and updated Portuguese content in separate files.
- The first two regression tests failed against the original registry implementation before the fix. Focused registry, backend, and i18n suites: 142 tests pass, including the existing file-collection slug-preservation test.
- Full `pnpm test` passes: lint (JavaScript, CSS, formatting), TypeScript, 4 Cypress-runner tests, and 1,388 Jest tests across 112 suites with 138 snapshots. The existing 1,304 skipped tests / 2 skipped suites remain skipped.
- `git diff --check` passes. No live GitHub/GitLab save or browser E2E was run. No dependency or lockfile changes.
- AI assistance: developed and validated with OpenAI Codex.

**Checklist**

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).
