### PR TITLE
fix(gitlab): include merge request SHA when publishing

### DIFF
--- a/packages/decap-cms-backend-gitlab/src/API.ts
+++ b/packages/decap-cms-backend-gitlab/src/API.ts
@@ -956,6 +956,7 @@ export default class API {
       method: 'PUT',
       url: `${this.repoURL}/merge_requests/${mergeRequest.iid}/merge`,
       params: {
+        sha: mergeRequest.sha,
         merge_commit_message: MERGE_COMMIT_MESSAGE,
         squash_commit_message: MERGE_COMMIT_MESSAGE,
         squash: this.squashMerges,

--- a/packages/decap-cms-backend-gitlab/src/__tests__/API.spec.js
+++ b/packages/decap-cms-backend-gitlab/src/__tests__/API.spec.js
@@ -180,6 +180,45 @@ describe('GitLab API', () => {
     });
   });
 
+  describe('publishUnpublishedEntry', () => {
+    test.each([false, true])(
+      'merges the fetched head SHA with squashMerges=%s',
+      async squashMerges => {
+        const api = new API({ repo: 'foo/bar', squashMerges });
+        const mergeRequest = { iid: 42, sha: 'reviewed-head-sha' };
+        api.getBranchMergeRequest = jest.fn().mockResolvedValue(mergeRequest);
+        api.requestJSON = jest.fn().mockResolvedValue({ state: 'merged' });
+
+        await api.publishUnpublishedEntry('posts', 'title');
+
+        expect(api.getBranchMergeRequest).toHaveBeenCalledWith('cms/posts/title');
+        expect(api.requestJSON).toHaveBeenCalledTimes(1);
+        expect(api.requestJSON).toHaveBeenCalledWith({
+          method: 'PUT',
+          url: '/projects/foo%2Fbar/merge_requests/42/merge',
+          params: expect.objectContaining({
+            sha: 'reviewed-head-sha',
+            squash: squashMerges,
+            should_remove_source_branch: true,
+          }),
+        });
+      },
+    );
+
+    test('propagates a changed-head rejection without retrying the merge', async () => {
+      const api = new API({ repo: 'foo/bar' });
+      const error = new Error('SHA does not match HEAD of source branch');
+      api.getBranchMergeRequest = jest.fn().mockResolvedValue({ iid: 42, sha: 'old-head-sha' });
+      api.requestJSON = jest.fn().mockRejectedValue(error);
+
+      await expect(api.publishUnpublishedEntry('posts', 'title')).rejects.toBe(error);
+
+      expect(api.getBranchMergeRequest).toHaveBeenCalledTimes(1);
+      expect(api.requestJSON).toHaveBeenCalledTimes(1);
+      expect(api.requestJSON.mock.calls[0][0].params.sha).toBe('old-head-sha');
+    });
+  });
+
   describe('getStatuses', () => {
     test('should get preview statuses', async () => {
       const api = new API({ repo: 'repo' });


### PR DESCRIPTION
**Summary**

Include the fetched merge request's `sha` when publishing an editorial-workflow entry through GitLab. Decap currently omits it, so publishing fails when the group or instance requires a commit SHA on the merge API.

[GitLab documents this conditional requirement](https://docs.gitlab.com/api/merge_requests/#merge-a-merge-request), and rejects a supplied SHA that no longer matches the branch head. The change uses the existing merge request lookup and preserves that rejection; it does not retry with a newer SHA. Squash settings and source-branch removal remain intact.

Fixes #7963.

**Test plan**

- Added three publish-path tests: SHA forwarding with squash enabled/disabled, and propagation of a changed-head rejection without another fetch or merge attempt. All three fail on original code and pass with the fix.
- GitLab backend Jest suite: 42 tests and 2 snapshots pass.
- Git Gateway Jest suite: 6 tests pass.
- Root TypeScript check, changed-file ESLint, Prettier, and diff whitespace checks pass.
- Production GitLab backend bundle builds with existing size warnings after setting `NODE_PATH` to the already-installed `url@0.11.4` dependency directory. Without that local resolution adjustment, Webpack cannot resolve `url/` before compilation; the same failure was verified on original source. No dependency or build-config changes are included.
- GitLab responses are mocked in these tests. A live GitLab publish and the full CMS/browser suite were not run.

**Checklist**

- [x] I have read the [contribution guidelines](https://github.com/decaporg/decap-cms/blob/main/CONTRIBUTING.md).
